### PR TITLE
Added equality tests for PrimitiveGroup

### DIFF
--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/PrimitiveGroup.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/PrimitiveGroup.cs
@@ -1,0 +1,146 @@
+using Mittons.Mapping.Extensions;
+
+namespace Mittons.Mapping.Protobuf.Messages.Osm;
+
+public class PrimitiveGroup : IEquatable<PrimitiveGroup>
+{
+    public List<Node> Nodes { get; init; } = [];
+    public List<Way> Ways { get; init; } = [];
+    public List<Relation> Relations { get; init; } = [];
+    public List<long> ChangeSets { get; init; } = [];
+
+    public const byte NodesFieldNumber = 1;
+    public const byte DenseNodesFieldNumber = 2;
+    public const byte WaysFieldNumber = 3;
+    public const byte RelationsFieldNumber = 4;
+    public const byte ChangeSetsFieldNumber = 5;
+
+    public bool Equals(PrimitiveGroup? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        if ((Nodes.Count != other.Nodes.Count) ||
+            (Ways.Count != other.Ways.Count) ||
+            (Relations.Count != other.Relations.Count) ||
+            (ChangeSets.Count != other.ChangeSets.Count))
+        {
+            return false;
+        }
+
+        for (int i = 0; i < Nodes.Count; ++i)
+        {
+            if (Nodes[i] != other.Nodes[i]) return false;
+        }
+
+        for (int i = 0; i < Ways.Count; ++i)
+        {
+            if (Ways[i] != other.Ways[i]) return false;
+        }
+
+        for (int i = 0; i < Relations.Count; ++i)
+        {
+            if (Relations[i] != other.Relations[i]) return false;
+        }
+
+        for (int i = 0; i < ChangeSets.Count; ++i)
+        {
+            if (ChangeSets[i] != other.ChangeSets[i]) return false;
+        }
+
+        return true;
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var node in Nodes)
+            hash.Add(node);
+        foreach (var ways in Ways)
+            hash.Add(ways);
+        foreach (var relations in Relations)
+            hash.Add(relations);
+        foreach (var changeSet in ChangeSets)
+            hash.Add(changeSet);
+        return hash.ToHashCode();
+    }
+    public static bool operator ==(PrimitiveGroup? left, PrimitiveGroup? right) => left?.Equals(right) ?? right is null;
+    public static bool operator !=(PrimitiveGroup? left, PrimitiveGroup? right) => !(left?.Equals(right) ?? right is null);
+    public override bool Equals(object? obj) => Equals(obj as PrimitiveGroup);
+}
+
+// internal static class PrimitiveGroupMemoryExtensions
+// {
+//     internal static IEnumerable<Node> AsDenseNodes(this Memory<byte> source)
+//     {
+//         Memory<byte> idBuffer = new();
+//         Memory<byte> denseInfoBuffer = new();
+//         Memory<byte> latitudeBuffer = new();
+//         Memory<byte> longitudeBuffer = new();
+//         Memory<byte> keyValueBuffer = new();
+
+//         int memoryPosition = 0;
+//         byte fieldDatatypeIdentifier;
+//         int denseLength;
+
+//         while (memoryPosition < source.Length)
+//         {
+//             fieldDatatypeIdentifier = source.Span[memoryPosition++];
+//             denseLength = source.ReadInt32(ref memoryPosition);
+
+//             switch (fieldDatatypeIdentifier >> 3)
+//             {
+//                 case DenseNodes.IdFieldNumber:
+//                     idBuffer = source.Slice(memoryPosition, denseLength);
+//                     break;
+//                 case DenseNodes.DenseInfoFieldNumber:
+//                     denseInfoBuffer = source.Slice(memoryPosition, denseLength);
+//                     break;
+//                 case DenseNodes.LatitudeFieldNumber:
+//                     latitudeBuffer = source.Slice(memoryPosition, denseLength);
+//                     break;
+//                 case DenseNodes.LongitudeFieldNumber:
+//                     longitudeBuffer = source.Slice(memoryPosition, denseLength);
+//                     break;
+//                 case DenseNodes.KeyValueFieldNumber:
+//                     keyValueBuffer = source.Slice(memoryPosition, denseLength);
+//                     break;
+//                 default:
+//                     throw new InvalidOperationException($"Unexpected field number {fieldDatatypeIdentifier >> 3} in DenseNodes.");
+//             }
+
+//             memoryPosition += denseLength;
+//         }
+
+//         int idPosition = 0;
+//         int infoPosition = 0;
+//         int latitudePosition = 0;
+//         int longitudePosition = 0;
+//         int keyValuePosition = 0;
+
+//         Node? previousNode = null;
+//         // TODO: This means the whole collection is materialized at once, what
+//         //       if we instead did something like override operator+ so we could
+//         //       read a dense info, then add the previous dense info to account
+//         //       for the SInts? Doesn't have to be an operator overload, but
+//         //       someway of updating the relative offsets.
+//         Info[] infos = [.. denseInfoBuffer.AsDenseInfo()];
+
+//         while (idPosition < idBuffer.Length)
+//         {
+//             List<(uint Key, uint Value)> keyValuePairs = keyValueBuffer.Length == 0 ? [] : keyValueBuffer.ReadKeyValuePairs(ref keyValuePosition);
+
+//             previousNode = new()
+//             {
+//                 Id = idBuffer.ReadSInt64(ref idPosition) + (previousNode?.Id ?? 0),
+//                 Info = infoPosition < infos.Length ? infos[infoPosition++] : null,
+//                 Latitude = latitudeBuffer.ReadSInt64(ref latitudePosition) + (previousNode?.Latitude ?? 0),
+//                 Longitude = longitudeBuffer.ReadSInt64(ref longitudePosition) + (previousNode?.Longitude ?? 0),
+//                 Keys = [.. keyValuePairs.Select(x => x.Key)],
+//                 Values = [.. keyValuePairs.Select(x => x.Value)],
+//             };
+
+//             yield return previousNode;
+//         }
+//     }
+// }

--- a/test/Mittons.Mapping.Tests/Data/Protobuf/Messages/Osm/PrimitiveGroupData/PrimitiveGroupEqualityData.cs
+++ b/test/Mittons.Mapping.Tests/Data/Protobuf/Messages/Osm/PrimitiveGroupData/PrimitiveGroupEqualityData.cs
@@ -1,0 +1,269 @@
+using Mittons.Mapping.Protobuf.Messages.Osm;
+
+namespace Mittons.Mapping.Tests.Data.Protobuf.Messages.Osm.PrimitiveGroupData;
+
+internal class PrimitiveGroupEqualityData : DataSourceGeneratorAttribute<PrimitiveGroup, PrimitiveGroup>
+{
+    protected override IEnumerable<Func<(PrimitiveGroup, PrimitiveGroup)>> GenerateDataSources(DataGeneratorMetadata dataGeneratorMetadata)
+    {
+        Node node1 = new()
+        {
+            Id = 1,
+            Keys = [3, 4],
+            Values = [5, 6],
+            Info = new()
+            {
+                Version = 0,
+                Timestamp = 1,
+                ChangeSet = 2,
+                UserId = 3,
+                UserStringId = 4,
+                IsVisible = true,
+            },
+            Latitude = 1,
+            Longitude = -2,
+        };
+
+        Node node2 = new()
+        {
+            Id = 1,
+            Keys = [5, 6],
+            Values = [3, 4],
+            Info = new()
+            {
+                Version = 2,
+                Timestamp = 3,
+                ChangeSet = 4,
+                UserId = 5,
+                UserStringId = 6,
+                IsVisible = false,
+            },
+            Latitude = -2,
+            Longitude = 1,
+        };
+
+        Way way1 = new()
+        {
+            Id = 1,
+            Keys = [3, 4],
+            Values = [5, 6],
+            Info = new()
+            {
+                Version = 0,
+                Timestamp = 1,
+                ChangeSet = 2,
+                UserId = 3,
+                UserStringId = 4,
+                IsVisible = true,
+            },
+            References = [1, -1],
+            Latitudes = [2, -1],
+            Longitudes = [3, -1],
+        };
+
+        Way way2 = new()
+        {
+            Id = 2,
+            Keys = [5],
+            Values = [7],
+            Info = new()
+            {
+                Version = 1,
+                Timestamp = 2,
+                ChangeSet = 3,
+                UserId = 4,
+                UserStringId = 5,
+                IsVisible = false,
+            },
+            References = [2],
+            Latitudes = [3],
+            Longitudes = [4],
+        };
+
+        Relation relations1 = new()
+        {
+            Id = 1,
+            Keys = [3, 4],
+            Values = [5, 6],
+            Info = new()
+            {
+                Version = 0,
+                Timestamp = 1,
+                ChangeSet = 2,
+                UserId = 3,
+                UserStringId = 4,
+                IsVisible = true,
+            },
+            RoleStringIds = [1, -2, 4],
+            MemberIds = [2, -3, 6],
+            MemberTypes = [Relation.MemberType.Node, Relation.MemberType.Way, Relation.MemberType.Relation]
+        };
+
+        Relation relations2 = new()
+        {
+            Id = 2,
+            Keys = [3, 4],
+            Values = [5, 6],
+            Info = new()
+            {
+                Version = 0,
+                Timestamp = 1,
+                ChangeSet = 2,
+                UserId = 3,
+                UserStringId = 4,
+                IsVisible = true,
+            },
+            RoleStringIds = [1, -2, 4],
+            MemberIds = [2, -3, 6],
+            MemberTypes = [Relation.MemberType.Node, Relation.MemberType.Way, Relation.MemberType.Relation]
+        };
+
+        long changeSet1 = 1;
+
+        long changeSet2 = 2;
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [node1, node2],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [node1, node2],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1, way2],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1, way2],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1, relations2],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1, relations2],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1, changeSet2],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1, changeSet2],
+            }
+        );
+    }
+}

--- a/test/Mittons.Mapping.Tests/Data/Protobuf/Messages/Osm/PrimitiveGroupData/PrimitiveGroupInequalityData.cs
+++ b/test/Mittons.Mapping.Tests/Data/Protobuf/Messages/Osm/PrimitiveGroupData/PrimitiveGroupInequalityData.cs
@@ -1,0 +1,485 @@
+using Mittons.Mapping.Protobuf.Messages.Osm;
+
+namespace Mittons.Mapping.Tests.Data.Protobuf.Messages.Osm.PrimitiveGroupData;
+
+internal class PrimitiveGroupInequalityData : DataSourceGeneratorAttribute<PrimitiveGroup, PrimitiveGroup>
+{
+    protected override IEnumerable<Func<(PrimitiveGroup, PrimitiveGroup)>> GenerateDataSources(DataGeneratorMetadata dataGeneratorMetadata)
+    {
+        Node node1 = new()
+        {
+            Id = 1,
+            Keys = [3, 4],
+            Values = [5, 6],
+            Info = new()
+            {
+                Version = 0,
+                Timestamp = 1,
+                ChangeSet = 2,
+                UserId = 3,
+                UserStringId = 4,
+                IsVisible = true,
+            },
+            Latitude = 1,
+            Longitude = -2,
+        };
+
+        Node node2 = new()
+        {
+            Id = 1,
+            Keys = [5, 6],
+            Values = [3, 4],
+            Info = new()
+            {
+                Version = 2,
+                Timestamp = 3,
+                ChangeSet = 4,
+                UserId = 5,
+                UserStringId = 6,
+                IsVisible = false,
+            },
+            Latitude = -2,
+            Longitude = 1,
+        };
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [node2],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [node1, node2],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [node2, node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [node1, node2],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [node2, node1],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        Way way1 = new()
+        {
+            Id = 1,
+            Keys = [3, 4],
+            Values = [5, 6],
+            Info = new()
+            {
+                Version = 0,
+                Timestamp = 1,
+                ChangeSet = 2,
+                UserId = 3,
+                UserStringId = 4,
+                IsVisible = true,
+            },
+            References = [1, -1],
+            Latitudes = [2, -1],
+            Longitudes = [3, -1],
+        };
+
+        Way way2 = new()
+        {
+            Id = 2,
+            Keys = [5],
+            Values = [7],
+            Info = new()
+            {
+                Version = 1,
+                Timestamp = 2,
+                ChangeSet = 3,
+                UserId = 4,
+                UserStringId = 5,
+                IsVisible = false,
+            },
+            References = [2],
+            Latitudes = [3],
+            Longitudes = [4],
+        };
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way2],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1, way2],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way2, way1],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1, way2],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way1],
+                Relations = [],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [way2, way1],
+                Relations = [],
+                ChangeSets = [],
+            }
+        );
+
+        Relation relations1 = new()
+        {
+            Id = 1,
+            Keys = [3, 4],
+            Values = [5, 6],
+            Info = new()
+            {
+                Version = 0,
+                Timestamp = 1,
+                ChangeSet = 2,
+                UserId = 3,
+                UserStringId = 4,
+                IsVisible = true,
+            },
+            RoleStringIds = [1, -2, 4],
+            MemberIds = [2, -3, 6],
+            MemberTypes = [Relation.MemberType.Node, Relation.MemberType.Way, Relation.MemberType.Relation]
+        };
+
+        Relation relations2 = new()
+        {
+            Id = 2,
+            Keys = [3, 4],
+            Values = [5, 6],
+            Info = new()
+            {
+                Version = 0,
+                Timestamp = 1,
+                ChangeSet = 2,
+                UserId = 3,
+                UserStringId = 4,
+                IsVisible = true,
+            },
+            RoleStringIds = [1, -2, 4],
+            MemberIds = [2, -3, 6],
+            MemberTypes = [Relation.MemberType.Node, Relation.MemberType.Way, Relation.MemberType.Relation]
+        };
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations2],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1, relations2],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations2, relations1],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1, relations2],
+                ChangeSets = [],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations1],
+                ChangeSets = [],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [relations2, relations1],
+                ChangeSets = [],
+            }
+        );
+
+        long changeSet1 = 1;
+
+        long changeSet2 = 2;
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet2],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1, changeSet2],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet2, changeSet1],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1, changeSet2],
+            }
+        );
+
+        yield return () =>
+        (
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet1],
+            },
+            new PrimitiveGroup()
+            {
+                Nodes = [],
+                Ways = [],
+                Relations = [],
+                ChangeSets = [changeSet2, changeSet1],
+            }
+        );
+    }
+}

--- a/test/Mittons.Mapping.Tests/Protobuf/Messages/Osm/PrimitiveGroupTests.cs
+++ b/test/Mittons.Mapping.Tests/Protobuf/Messages/Osm/PrimitiveGroupTests.cs
@@ -1,0 +1,41 @@
+using Mittons.Mapping.Protobuf.Messages.Osm;
+using Mittons.Mapping.Tests.Data.Protobuf.Messages.Osm.PrimitiveGroupData;
+
+namespace Mittons.Mapping.Tests.Protobuf.Messages.Osm;
+
+public class PrimitiveGroupTests
+{
+    [Test]
+    [PrimitiveGroupEqualityData]
+    public async Task EqualityTests(PrimitiveGroup left, PrimitiveGroup right)
+    {
+        // Arrange
+
+        // Act
+        var actualEqualityFunctionResult = left.Equals(right);
+        var actualEqualityOperatorResult = left == right;
+        var actualInequalityOperatorResult = left != right;
+
+        // Assert
+        await Assert.That(actualEqualityFunctionResult).IsTrue();
+        await Assert.That(actualEqualityOperatorResult).IsTrue();
+        await Assert.That(actualInequalityOperatorResult).IsFalse();
+    }
+
+    [Test]
+    [PrimitiveGroupInequalityData]
+    public async Task InequalityTests(PrimitiveGroup left, PrimitiveGroup right)
+    {
+        // Arrange
+
+        // Act
+        var actualEqualityFunctionResult = left.Equals(right);
+        var actualEqualityOperatorResult = left == right;
+        var actualInequalityOperatorResult = left != right;
+
+        // Assert
+        await Assert.That(actualEqualityFunctionResult).IsFalse();
+        await Assert.That(actualEqualityOperatorResult).IsFalse();
+        await Assert.That(actualInequalityOperatorResult).IsTrue();
+    }
+}


### PR DESCRIPTION
This adds the equality tests as a precursor to the actual reading of PrimitiveGroup to address #9. This is being merged now so we can follow up with a separate PR that will update the code to target netstandard2.0 and 2.1 before I can finish implementing PrimitiveGroup.