### PR TITLE
Netstandard support

### DIFF
--- a/src/Mittons.Mapping/Extensions/LengthDelimitedMemoryExtensions.cs
+++ b/src/Mittons.Mapping/Extensions/LengthDelimitedMemoryExtensions.cs
@@ -1,294 +1,297 @@
+using System;
+using System.Collections.Generic;
 using System.Text;
 
-namespace Mittons.Mapping.Extensions;
-
-public static class ReadLengthDelimitedMemoryExtensions
+namespace Mittons.Mapping.Extensions
 {
-    public static string ReadString(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsString();
-
-    public static string? ReadNullableString(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsNullableString();
-
-    public static byte[] ReadBytes(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsBytes();
-
-    public static IEnumerable<string> ReadPackedRepeatedStrings(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedStringFields();
-
-    public static IEnumerable<T> ReadPackedEnum<T>(this Memory<byte> memory, ref int memoryPosition) where T : Enum
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedEnumFields<T>();
-
-    public static IEnumerable<int> ReadPackedInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedInt32Fields();
-
-    public static IEnumerable<long> ReadPackedInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedInt64Fields();
-
-    public static IEnumerable<int> ReadPackedSInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedSInt32Fields();
-
-    public static IEnumerable<long> ReadPackedSInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedSInt64Fields();
-
-    public static IEnumerable<uint> ReadPackedUInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedUInt32Fields();
-
-    public static IEnumerable<ulong> ReadPackedUInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedUInt64Fields();
-
-    public static IEnumerable<int> ReadPackedDeltaCodedInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedInt32Fields();
-
-    public static IEnumerable<long> ReadPackedDeltaCodedInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedInt64Fields();
-
-    public static IEnumerable<int> ReadPackedDeltaCodedSInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedSInt32Fields();
-
-    public static IEnumerable<long> ReadPackedDeltaCodedSInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedSInt64Fields();
-
-    public static IEnumerable<uint> ReadPackedDeltaCodedUInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedUInt32Fields();
-
-    public static IEnumerable<ulong> ReadPackedDeltaCodedUInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedUInt64Fields();
-
-    internal static Memory<byte> ReadLengthDelimited(this Memory<byte> memory, ref int memoryPosition)
+    public static class ReadLengthDelimitedMemoryExtensions
     {
-        var length = memory.ReadVarInt(ref memoryPosition).AsUInt16();
+        public static string ReadString(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsString();
 
-        Memory<byte> result = memory.Slice(memoryPosition, length);
+        public static string? ReadNullableString(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsNullableString();
 
-        memoryPosition += length;
+        public static byte[] ReadBytes(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsBytes();
 
-        return result;
-    }
+        public static IEnumerable<string> ReadPackedRepeatedStrings(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedStringFields();
 
-    internal static List<(uint Key, uint Value)> ReadKeyValuePairs(this Memory<byte> memory, ref int memoryPosition)
-    {
-        List<(uint Key, uint Value)> pairs = [];
+        public static IEnumerable<T> ReadPackedEnum<T>(this Memory<byte> memory, ref int memoryPosition) where T : Enum
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedEnumFields<T>();
 
-        for (uint key = memory.ReadUInt32(ref memoryPosition); key != 0; key = memory.ReadUInt32(ref memoryPosition))
+        public static IEnumerable<int> ReadPackedInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedInt32Fields();
+
+        public static IEnumerable<long> ReadPackedInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedInt64Fields();
+
+        public static IEnumerable<int> ReadPackedSInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedSInt32Fields();
+
+        public static IEnumerable<long> ReadPackedSInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedSInt64Fields();
+
+        public static IEnumerable<uint> ReadPackedUInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedUInt32Fields();
+
+        public static IEnumerable<ulong> ReadPackedUInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedUInt64Fields();
+
+        public static IEnumerable<int> ReadPackedDeltaCodedInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedInt32Fields();
+
+        public static IEnumerable<long> ReadPackedDeltaCodedInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedInt64Fields();
+
+        public static IEnumerable<int> ReadPackedDeltaCodedSInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedSInt32Fields();
+
+        public static IEnumerable<long> ReadPackedDeltaCodedSInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedSInt64Fields();
+
+        public static IEnumerable<uint> ReadPackedDeltaCodedUInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedUInt32Fields();
+
+        public static IEnumerable<ulong> ReadPackedDeltaCodedUInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadLengthDelimited(ref memoryPosition).AsPackedRepeatedDeltaCodedUInt64Fields();
+
+        internal static Memory<byte> ReadLengthDelimited(this Memory<byte> memory, ref int memoryPosition)
         {
-            uint value = memory.ReadUInt32(ref memoryPosition);
+            var length = memory.ReadVarInt(ref memoryPosition).AsUInt16();
 
-            pairs.Add(new(key, value));
+            Memory<byte> result = memory.Slice(memoryPosition, length);
+
+            memoryPosition += length;
+
+            return result;
         }
 
-        return pairs;
-    }
-
-    internal static string AsString(this Memory<byte> memory)
-    {
-        return Encoding.UTF8.GetString(memory.Span);
-    }
-
-    internal static string? AsNullableString(this Memory<byte> memory)
-    {
-        return memory.Length == 0 ? null : Encoding.UTF8.GetString(memory.Span);
-    }
-
-    internal static byte[] AsBytes(this Memory<byte> memory)
-    {
-        return memory.ToArray();
-    }
-
-    internal static byte[] AsEmbeddedMessages(this Memory<byte> memory)
-    {
-        throw new NotImplementedException();
-    }
-
-    internal static IEnumerable<string> AsPackedRepeatedStringFields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static List<(uint Key, uint Value)> ReadKeyValuePairs(this Memory<byte> memory, ref int memoryPosition)
         {
-            Memory<byte> lengthDelimited = memory.ReadLengthDelimited(ref memoryPosition);
+            List<(uint Key, uint Value)> pairs = new List<(uint Key, uint Value)>();
 
-            yield return lengthDelimited.AsString();
+            for (uint key = memory.ReadUInt32(ref memoryPosition); key != 0; key = memory.ReadUInt32(ref memoryPosition))
+            {
+                uint value = memory.ReadUInt32(ref memoryPosition);
+
+                pairs.Add((key, value));
+            }
+
+            return pairs;
         }
-    }
 
-    internal static IEnumerable<T> AsPackedRepeatedEnumFields<T>(this Memory<byte> memory) where T : Enum
-    {
-        int memoryPosition = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static string AsString(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
-
-            yield return lengthDelimited.AsEnum<T>();
+            return Encoding.UTF8.GetString(memory.ToArray());
         }
-    }
 
-    internal static IEnumerable<int> AsPackedRepeatedInt32Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static string? AsNullableString(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
-
-            yield return lengthDelimited.AsInt32();
+            return memory.Length == 0 ? null : Encoding.UTF8.GetString(memory.ToArray());
         }
-    }
 
-    internal static IEnumerable<long> AsPackedRepeatedInt64Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static byte[] AsBytes(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
-
-            yield return lengthDelimited.AsInt64();
+            return memory.ToArray();
         }
-    }
 
-    internal static IEnumerable<int> AsPackedRepeatedSInt32Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static byte[] AsEmbeddedMessages(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
-
-            yield return lengthDelimited.AsSInt32();
+            throw new NotImplementedException();
         }
-    }
 
-    internal static IEnumerable<long> AsPackedRepeatedSInt64Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<string> AsPackedRepeatedStringFields(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            yield return lengthDelimited.AsSInt64();
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadLengthDelimited(ref memoryPosition);
+
+                yield return lengthDelimited.AsString();
+            }
         }
-    }
 
-    internal static IEnumerable<uint> AsPackedRepeatedUInt32Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<T> AsPackedRepeatedEnumFields<T>(this Memory<byte> memory) where T : Enum
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            yield return lengthDelimited.AsUInt32();
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+
+                yield return lengthDelimited.AsEnum<T>();
+            }
         }
-    }
 
-    internal static IEnumerable<ulong> AsPackedRepeatedUInt64Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<int> AsPackedRepeatedInt32Fields(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            yield return lengthDelimited.AsUInt64();
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+
+                yield return lengthDelimited.AsInt32();
+            }
         }
-    }
 
-    internal static IEnumerable<int> AsPackedRepeatedDeltaCodedInt32Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        int previousValue = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<long> AsPackedRepeatedInt64Fields(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            previousValue += lengthDelimited.AsInt32();
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
 
-            yield return previousValue;
+                yield return lengthDelimited.AsInt64();
+            }
         }
-    }
 
-    internal static IEnumerable<long> AsPackedRepeatedDeltaCodedInt64Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        long previousValue = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<int> AsPackedRepeatedSInt32Fields(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            previousValue += lengthDelimited.AsInt64();
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
 
-            yield return previousValue;
+                yield return lengthDelimited.AsSInt32();
+            }
         }
-    }
 
-    internal static IEnumerable<int> AsPackedRepeatedDeltaCodedSInt32Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        int previousValue = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<long> AsPackedRepeatedSInt64Fields(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            previousValue += lengthDelimited.AsSInt32();
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
 
-            yield return previousValue;
+                yield return lengthDelimited.AsSInt64();
+            }
         }
-    }
 
-    internal static IEnumerable<long> AsPackedRepeatedDeltaCodedSInt64Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        long previousValue = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<uint> AsPackedRepeatedUInt32Fields(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            previousValue += lengthDelimited.AsSInt64();
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
 
-            yield return previousValue;
+                yield return lengthDelimited.AsUInt32();
+            }
         }
-    }
 
-    internal static IEnumerable<uint> AsPackedRepeatedDeltaCodedUInt32Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        uint previousValue = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<ulong> AsPackedRepeatedUInt64Fields(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            previousValue += lengthDelimited.AsUInt32();
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
 
-            yield return previousValue;
+                yield return lengthDelimited.AsUInt64();
+            }
         }
-    }
 
-    internal static IEnumerable<ulong> AsPackedRepeatedDeltaCodedUInt64Fields(this Memory<byte> memory)
-    {
-        int memoryPosition = 0;
-
-        ulong previousValue = 0;
-
-        while (memoryPosition < memory.Length)
+        internal static IEnumerable<int> AsPackedRepeatedDeltaCodedInt32Fields(this Memory<byte> memory)
         {
-            Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+            int memoryPosition = 0;
 
-            previousValue += lengthDelimited.AsUInt64();
+            int previousValue = 0;
 
-            yield return previousValue;
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+
+                previousValue += lengthDelimited.AsInt32();
+
+                yield return previousValue;
+            }
+        }
+
+        internal static IEnumerable<long> AsPackedRepeatedDeltaCodedInt64Fields(this Memory<byte> memory)
+        {
+            int memoryPosition = 0;
+
+            long previousValue = 0;
+
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+
+                previousValue += lengthDelimited.AsInt64();
+
+                yield return previousValue;
+            }
+        }
+
+        internal static IEnumerable<int> AsPackedRepeatedDeltaCodedSInt32Fields(this Memory<byte> memory)
+        {
+            int memoryPosition = 0;
+
+            int previousValue = 0;
+
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+
+                previousValue += lengthDelimited.AsSInt32();
+
+                yield return previousValue;
+            }
+        }
+
+        internal static IEnumerable<long> AsPackedRepeatedDeltaCodedSInt64Fields(this Memory<byte> memory)
+        {
+            int memoryPosition = 0;
+
+            long previousValue = 0;
+
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+
+                previousValue += lengthDelimited.AsSInt64();
+
+                yield return previousValue;
+            }
+        }
+
+        internal static IEnumerable<uint> AsPackedRepeatedDeltaCodedUInt32Fields(this Memory<byte> memory)
+        {
+            int memoryPosition = 0;
+
+            uint previousValue = 0;
+
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+
+                previousValue += lengthDelimited.AsUInt32();
+
+                yield return previousValue;
+            }
+        }
+
+        internal static IEnumerable<ulong> AsPackedRepeatedDeltaCodedUInt64Fields(this Memory<byte> memory)
+        {
+            int memoryPosition = 0;
+
+            ulong previousValue = 0;
+
+            while (memoryPosition < memory.Length)
+            {
+                Memory<byte> lengthDelimited = memory.ReadVarInt(ref memoryPosition);
+
+                previousValue += lengthDelimited.AsUInt64();
+
+                yield return previousValue;
+            }
         }
     }
 }

--- a/src/Mittons.Mapping/Extensions/VarIntMemoryExtensions.cs
+++ b/src/Mittons.Mapping/Extensions/VarIntMemoryExtensions.cs
@@ -1,127 +1,130 @@
-namespace Mittons.Mapping.Extensions;
+using System;
 
-public static class VarIntMemoryExtensions
+namespace Mittons.Mapping.Extensions
 {
-    public static bool ReadBool(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadVarInt(ref memoryPosition).AsBool();
-
-    public static T ReadEnum<T>(this Memory<byte> memory, ref int memoryPosition) where T : Enum
-        => memory.ReadVarInt(ref memoryPosition).AsEnum<T>();
-
-    public static int ReadInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadVarInt(ref memoryPosition).AsInt32();
-
-    public static long ReadInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadVarInt(ref memoryPosition).AsInt64();
-
-    public static int ReadSInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadVarInt(ref memoryPosition).AsSInt32();
-
-    public static long ReadSInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadVarInt(ref memoryPosition).AsSInt64();
-
-    public static ushort ReadUInt16(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadVarInt(ref memoryPosition).AsUInt16();
-
-    public static uint ReadUInt32(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadVarInt(ref memoryPosition).AsUInt32();
-
-    public static ulong ReadUInt64(this Memory<byte> memory, ref int memoryPosition)
-        => memory.ReadVarInt(ref memoryPosition).AsUInt64();
-
-    internal static Memory<byte> ReadVarInt(this Memory<byte> memory, ref int memoryPosition)
+    public static class VarIntMemoryExtensions
     {
-        byte count = 0;
+        public static bool ReadBool(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadVarInt(ref memoryPosition).AsBool();
 
-        do { ++count; } while ((memory.Span[memoryPosition + count - 1] & 0x80) != 0);
+        public static T ReadEnum<T>(this Memory<byte> memory, ref int memoryPosition) where T : Enum
+            => memory.ReadVarInt(ref memoryPosition).AsEnum<T>();
 
-        Memory<byte> result = memory.Slice(memoryPosition, count);
+        public static int ReadInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadVarInt(ref memoryPosition).AsInt32();
 
-        memoryPosition += count;
+        public static long ReadInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadVarInt(ref memoryPosition).AsInt64();
 
-        return result;
+        public static int ReadSInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadVarInt(ref memoryPosition).AsSInt32();
+
+        public static long ReadSInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadVarInt(ref memoryPosition).AsSInt64();
+
+        public static ushort ReadUInt16(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadVarInt(ref memoryPosition).AsUInt16();
+
+        public static uint ReadUInt32(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadVarInt(ref memoryPosition).AsUInt32();
+
+        public static ulong ReadUInt64(this Memory<byte> memory, ref int memoryPosition)
+            => memory.ReadVarInt(ref memoryPosition).AsUInt64();
+
+        internal static Memory<byte> ReadVarInt(this Memory<byte> memory, ref int memoryPosition)
+        {
+            byte count = 0;
+
+            do { ++count; } while ((memory.Span[memoryPosition + count - 1] & 0x80) != 0);
+
+            Memory<byte> result = memory.Slice(memoryPosition, count);
+
+            memoryPosition += count;
+
+            return result;
+        }
+
+        internal static bool AsBool(this Memory<byte> memory)
+            => memory.Span[0] != 0;
+
+        internal static T AsEnum<T>(this Memory<byte> memory) where T : Enum
+            => (T)(object)memory.AsInt32();
+
+        internal static int AsInt32(this Memory<byte> memory)
+            => memory.Length switch
+            {
+                1 => memory.Span[0],
+                2 => (memory.Span[0] & 0x7f) | (memory.Span[1] << 7),
+                3 => (memory.Span[0] & 0x7f) | ((memory.Span[1] & 0x7f) << 7) | (memory.Span[2] << 14),
+                4 => (memory.Span[0] & 0x7f) | ((memory.Span[1] & 0x7f) << 7) | ((memory.Span[2] & 0x7f) << 14) | (memory.Span[3] << 21),
+                5 => (memory.Span[0] & 0x7f) | ((memory.Span[1] & 0x7f) << 7) | ((memory.Span[2] & 0x7f) << 14) | ((memory.Span[3] & 0x7f) << 21) | (memory.Span[4] << 28),
+                _ => throw new InvalidOperationException("VarInt is too large to fit in an Int32."),
+            };
+
+        internal static long AsInt64(this Memory<byte> memory)
+            => memory.Length switch
+            {
+                1 => (long)memory.Span[0],
+                2 => ((long)memory.Span[0] & 0x7f) | ((long)memory.Span[1] << 7),
+                3 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | ((long)memory.Span[2] << 14),
+                4 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21),
+                5 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28),
+                6 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35),
+                7 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35) | (((long)memory.Span[6] & 0x7f) << 42),
+                8 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35) | (((long)memory.Span[6] & 0x7f) << 42) | (((long)memory.Span[7] & 0x7f) << 49),
+                9 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35) | (((long)memory.Span[6] & 0x7f) << 42) | (((long)memory.Span[7] & 0x7f) << 49) | (((long)memory.Span[8] & 0x7f) << 56),
+                10 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35) | (((long)memory.Span[6] & 0x7f) << 42) | (((long)memory.Span[7] & 0x7f) << 49) | (((long)memory.Span[8] & 0x7f) << 56) | ((long)memory.Span[9] << 63),
+                _ => throw new InvalidOperationException("VarInt is too large to fit in an Int64."),
+            };
+
+        internal static int AsSInt32(this Memory<byte> memory)
+        {
+            uint value = memory.AsUInt32();
+
+            return (int)((value >> 1) ^ -(value & 1));
+        }
+
+        internal static long AsSInt64(this Memory<byte> memory)
+        {
+            ulong value = memory.AsUInt64();
+
+            return (value & 1) == 0 ? (long)(value >> 1) : (long)(value >> 1) * -1 - 1;
+        }
+
+        internal static ushort AsUInt16(this Memory<byte> memory)
+            => memory.Length switch
+            {
+                1 => memory.Span[0],
+                2 => (ushort)((memory.Span[0] & 0x7f) | (memory.Span[1] << 7)),
+                3 => (ushort)((memory.Span[0] & 0x7f) | ((memory.Span[1] & 0x7f) << 7) | (memory.Span[2] << 14)),
+                _ => throw new InvalidOperationException("VarInt is too large to fit in an Int32."),
+            };
+
+        internal static uint AsUInt32(this Memory<byte> memory)
+            => memory.Length switch
+            {
+                1 => memory.Span[0],
+                2 => 0u | ((uint)memory.Span[1] << 7) | ((uint)memory.Span[0] & 0x7f),
+                3 => 0u | ((uint)memory.Span[2] << 14) | ((uint)(memory.Span[1] & 0x7f) << 7) | ((uint)memory.Span[0] & 0x7f),
+                4 => 0u | ((uint)memory.Span[3] << 21) | ((uint)(memory.Span[2] & 0x7f) << 14) | ((uint)(memory.Span[1] & 0x7f) << 7) | ((uint)memory.Span[0] & 0x7f),
+                5 => 0u | ((uint)memory.Span[4] << 28) | ((uint)(memory.Span[3] & 0x7f) << 21) | ((uint)(memory.Span[2] & 0x7f) << 14) | ((uint)(memory.Span[1] & 0x7f) << 7) | ((uint)memory.Span[0] & 0x7f),
+                _ => throw new InvalidOperationException("VarInt is too large to fit in an Int32."),
+            };
+
+        internal static ulong AsUInt64(this Memory<byte> memory)
+            => memory.Length switch
+            {
+                1 => memory.Span[0],
+                2 => 0UL | ((ulong)memory.Span[1] << 7) | ((ulong)memory.Span[0] & 0x7f),
+                3 => 0UL | ((ulong)memory.Span[2] << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
+                4 => 0UL | ((ulong)memory.Span[3] << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
+                5 => 0UL | ((ulong)memory.Span[4] << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
+                6 => 0UL | ((ulong)memory.Span[5] << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
+                7 => 0UL | ((ulong)memory.Span[6] << 42) | ((ulong)(memory.Span[5] & 0x7f) << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
+                8 => 0UL | ((ulong)memory.Span[7] << 49) | ((ulong)(memory.Span[6] & 0x7f) << 42) | ((ulong)(memory.Span[5] & 0x7f) << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
+                9 => 0UL | ((ulong)memory.Span[8] << 56) | ((ulong)(memory.Span[7] & 0x7f) << 49) | ((ulong)(memory.Span[6] & 0x7f) << 42) | ((ulong)(memory.Span[5] & 0x7f) << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
+                10 => 0UL | ((ulong)memory.Span[9] << 63) | ((ulong)(memory.Span[8] & 0x7f) << 56) | ((ulong)(memory.Span[7] & 0x7f) << 49) | ((ulong)(memory.Span[6] & 0x7f) << 42) | ((ulong)(memory.Span[5] & 0x7f) << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
+                _ => throw new InvalidOperationException("VarInt is too large to fit in an Int64."),
+            };
     }
-
-    internal static bool AsBool(this Memory<byte> memory)
-        => memory.Span[0] != 0;
-
-    internal static T AsEnum<T>(this Memory<byte> memory) where T : Enum
-        => (T)(object)memory.AsInt32();
-
-    internal static int AsInt32(this Memory<byte> memory)
-        => memory.Length switch
-        {
-            1 => memory.Span[0],
-            2 => (memory.Span[0] & 0x7f) | (memory.Span[1] << 7),
-            3 => (memory.Span[0] & 0x7f) | ((memory.Span[1] & 0x7f) << 7) | (memory.Span[2] << 14),
-            4 => (memory.Span[0] & 0x7f) | ((memory.Span[1] & 0x7f) << 7) | ((memory.Span[2] & 0x7f) << 14) | (memory.Span[3] << 21),
-            5 => (memory.Span[0] & 0x7f) | ((memory.Span[1] & 0x7f) << 7) | ((memory.Span[2] & 0x7f) << 14) | ((memory.Span[3] & 0x7f) << 21) | (memory.Span[4] << 28),
-            _ => throw new InvalidOperationException("VarInt is too large to fit in an Int32."),
-        };
-
-    internal static long AsInt64(this Memory<byte> memory)
-        => memory.Length switch
-        {
-            1 => (long)memory.Span[0],
-            2 => ((long)memory.Span[0] & 0x7f) | ((long)memory.Span[1] << 7),
-            3 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | ((long)memory.Span[2] << 14),
-            4 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21),
-            5 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28),
-            6 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35),
-            7 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35) | (((long)memory.Span[6] & 0x7f) << 42),
-            8 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35) | (((long)memory.Span[6] & 0x7f) << 42) | (((long)memory.Span[7] & 0x7f) << 49),
-            9 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35) | (((long)memory.Span[6] & 0x7f) << 42) | (((long)memory.Span[7] & 0x7f) << 49) | (((long)memory.Span[8] & 0x7f) << 56),
-            10 => ((long)memory.Span[0] & 0x7f) | (((long)memory.Span[1] & 0x7f) << 7) | (((long)memory.Span[2] & 0x7f) << 14) | (((long)memory.Span[3] & 0x7f) << 21) | (((long)memory.Span[4] & 0x7f) << 28) | (((long)memory.Span[5] & 0x7f) << 35) | (((long)memory.Span[6] & 0x7f) << 42) | (((long)memory.Span[7] & 0x7f) << 49) | (((long)memory.Span[8] & 0x7f) << 56) | ((long)memory.Span[9] << 63),
-            _ => throw new InvalidOperationException("VarInt is too large to fit in an Int64."),
-        };
-
-    internal static int AsSInt32(this Memory<byte> memory)
-    {
-        uint value = memory.AsUInt32();
-
-        return (int)((value >> 1) ^ -(value & 1));
-    }
-
-    internal static long AsSInt64(this Memory<byte> memory)
-    {
-        ulong value = memory.AsUInt64();
-
-        return (value & 1) == 0 ? (long)(value >> 1) : (long)(value >> 1) * -1 - 1;
-    }
-
-    internal static ushort AsUInt16(this Memory<byte> memory)
-        => memory.Length switch
-        {
-            1 => memory.Span[0],
-            2 => (ushort)((memory.Span[0] & 0x7f) | (memory.Span[1] << 7)),
-            3 => (ushort)((memory.Span[0] & 0x7f) | ((memory.Span[1] & 0x7f) << 7) | (memory.Span[2] << 14)),
-            _ => throw new InvalidOperationException("VarInt is too large to fit in an Int32."),
-        };
-
-    internal static uint AsUInt32(this Memory<byte> memory)
-        => memory.Length switch
-        {
-            1 => memory.Span[0],
-            2 => 0u | ((uint)memory.Span[1] << 7) | ((uint)memory.Span[0] & 0x7f),
-            3 => 0u | ((uint)memory.Span[2] << 14) | ((uint)(memory.Span[1] & 0x7f) << 7) | ((uint)memory.Span[0] & 0x7f),
-            4 => 0u | ((uint)memory.Span[3] << 21) | ((uint)(memory.Span[2] & 0x7f) << 14) | ((uint)(memory.Span[1] & 0x7f) << 7) | ((uint)memory.Span[0] & 0x7f),
-            5 => 0u | ((uint)memory.Span[4] << 28) | ((uint)(memory.Span[3] & 0x7f) << 21) | ((uint)(memory.Span[2] & 0x7f) << 14) | ((uint)(memory.Span[1] & 0x7f) << 7) | ((uint)memory.Span[0] & 0x7f),
-            _ => throw new InvalidOperationException("VarInt is too large to fit in an Int32."),
-        };
-
-    internal static ulong AsUInt64(this Memory<byte> memory)
-        => memory.Length switch
-        {
-            1 => memory.Span[0],
-            2 => 0UL | ((ulong)memory.Span[1] << 7) | ((ulong)memory.Span[0] & 0x7f),
-            3 => 0UL | ((ulong)memory.Span[2] << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
-            4 => 0UL | ((ulong)memory.Span[3] << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
-            5 => 0UL | ((ulong)memory.Span[4] << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
-            6 => 0UL | ((ulong)memory.Span[5] << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
-            7 => 0UL | ((ulong)memory.Span[6] << 42) | ((ulong)(memory.Span[5] & 0x7f) << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
-            8 => 0UL | ((ulong)memory.Span[7] << 49) | ((ulong)(memory.Span[6] & 0x7f) << 42) | ((ulong)(memory.Span[5] & 0x7f) << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
-            9 => 0UL | ((ulong)memory.Span[8] << 56) | ((ulong)(memory.Span[7] & 0x7f) << 49) | ((ulong)(memory.Span[6] & 0x7f) << 42) | ((ulong)(memory.Span[5] & 0x7f) << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
-            10 => 0UL | ((ulong)memory.Span[9] << 63) | ((ulong)(memory.Span[8] & 0x7f) << 56) | ((ulong)(memory.Span[7] & 0x7f) << 49) | ((ulong)(memory.Span[6] & 0x7f) << 42) | ((ulong)(memory.Span[5] & 0x7f) << 35) | ((ulong)(memory.Span[4] & 0x7f) << 28) | ((ulong)(memory.Span[3] & 0x7f) << 21) | ((ulong)(memory.Span[2] & 0x7f) << 14) | ((ulong)(memory.Span[1] & 0x7f) << 7) | ((ulong)memory.Span[0] & 0x7f),
-            _ => throw new InvalidOperationException("VarInt is too large to fit in an Int64."),
-        };
 }

--- a/src/Mittons.Mapping/IO/Streams/ManagedMemoryStream.cs
+++ b/src/Mittons.Mapping/IO/Streams/ManagedMemoryStream.cs
@@ -1,63 +1,72 @@
-namespace Mittons.Mapping.IO.Streams;
+using System;
+using System.IO;
 
-// TODO: Create test cases, this was copied from an earlier prototype
-public class ManagedMemoryStream(Memory<byte> memory) : Stream
+namespace Mittons.Mapping.IO.Streams
 {
-    private readonly Memory<byte> _memory = memory;
-
-    public override bool CanRead => true;
-    public override bool CanSeek => true;
-    public override bool CanWrite => false;
-    public override long Length => _memory.Length;
-    private int _position;
-    public override long Position
+    // TODO: Create test cases, this was copied from an earlier prototype
+    public class ManagedMemoryStream : Stream
     {
-        get => _position;
-        set => _position = (int)value;
-    }
-
-    public override void Flush()
-    {
-        throw new NotImplementedException();
-    }
-
-    public override int Read(byte[] buffer, int offset, int count)
-    {
-        var positionalOffset = _position + offset;
-        var readCount = Math.Min(count, _memory.Length - positionalOffset);
-
-        _memory.Span.Slice(positionalOffset, readCount).CopyTo(buffer.AsSpan());
-
-        _position += readCount;
-
-        return readCount;
-    }
-
-    public override long Seek(long offset, SeekOrigin origin)
-    {
-        switch (origin)
+        public ManagedMemoryStream(Memory<byte> memory)
         {
-            case SeekOrigin.Begin:
-                Position = offset;
-                break;
-            case SeekOrigin.Current:
-                Position += offset;
-                break;
-            case SeekOrigin.End:
-                Position = Length + offset;
-                break;
+            _memory = memory;
         }
 
-        return Position;
-    }
+        private readonly Memory<byte> _memory;
 
-    public override void SetLength(long value)
-    {
-        throw new NotImplementedException();
-    }
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _memory.Length;
+        private int _position;
+        public override long Position
+        {
+            get => _position;
+            set => _position = (int)value;
+        }
 
-    public override void Write(byte[] buffer, int offset, int count)
-    {
-        throw new NotImplementedException();
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var positionalOffset = _position + offset;
+            var readCount = Math.Min(count, _memory.Length - positionalOffset);
+
+            _memory.Span.Slice(positionalOffset, readCount).CopyTo(buffer.AsSpan());
+
+            _position += readCount;
+
+            return readCount;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    Position = offset;
+                    break;
+                case SeekOrigin.Current:
+                    Position += offset;
+                    break;
+                case SeekOrigin.End:
+                    Position = Length + offset;
+                    break;
+            }
+
+            return Position;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Mittons.Mapping/Mittons.Mapping.csproj
+++ b/src/Mittons.Mapping/Mittons.Mapping.csproj
@@ -1,14 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net10.0;</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Mittons.Mapping.Tests" />
     <InternalsVisibleTo Include="Mittons.Mapping.Benchmarks" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ZLibDotNet" Version="0.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Mittons.Mapping/Mittons.Mapping.csproj
+++ b/src/Mittons.Mapping/Mittons.Mapping.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="ZLibDotNet" Version="0.1.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
   </ItemGroup>

--- a/src/Mittons.Mapping/Mittons.Mapping.csproj
+++ b/src/Mittons.Mapping/Mittons.Mapping.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net10.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/Blob.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/Blob.cs
@@ -1,127 +1,136 @@
+// using System.IO.Compression;
+using System;
+using System.IO;
 using System.IO.Compression;
 using Mittons.Mapping.Extensions;
 using Mittons.Mapping.IO.Streams;
+using ZLibDotNet;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class Blob
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    private uint? _uncompressedSize;
-
-    /// <summary>
-    /// When compressed, this is the size of the uncompressed data.
-    /// </summary>
-    public uint UncompressedSize
+    public class Blob
     {
-        get
+        private uint? _uncompressedSize;
+
+        /// <summary>
+        /// When compressed, this is the size of the uncompressed data.
+        /// </summary>
+        public uint UncompressedSize
         {
-            if (_uncompressedSize.HasValue)
+            get
             {
-                return _uncompressedSize.Value;
-            }
-
-            return (uint)MessageData.Length;
-        }
-
-        init => _uncompressedSize = value;
-    }
-
-    /// <summary>
-    /// The data in the message, it may be compressed or uncompressed.
-    /// </summary>
-    public Memory<byte> MessageData { get; init; }
-
-    public Memory<byte> GetUncompressedData(byte[] buffer)
-    {
-        switch (CompressionAlgorithm)
-        {
-            case CompressionAlgorithm.Raw:
-                return MessageData;
-            case CompressionAlgorithm.ZLib:
+                if (_uncompressedSize.HasValue)
                 {
-                    ManagedMemoryStream compressedStream = new(MessageData);
-                    using ZLibStream zlibStream = new(compressedStream, CompressionMode.Decompress, true);
-                    using MemoryStream decompressedStream = new(buffer);
-
-                    zlibStream.CopyTo(decompressedStream);
-
-                    return buffer;
+                    return _uncompressedSize.Value;
                 }
-            case CompressionAlgorithm.Lzma:
-            case CompressionAlgorithm.Bzip2:
-            case CompressionAlgorithm.Lz4:
-            case CompressionAlgorithm.Zstd:
-                throw new NotImplementedException("GetUncompressedData with buffer is only implemented for ZLib compressed blobs.");
-            default:
-                throw new InvalidOperationException("Uncompressed data is not available for compressed blobs.");
-        }
-    }
 
-    internal CompressionAlgorithm CompressionAlgorithm { get; init; }
-
-    public const byte RawDataFieldNumber = 1;
-    public const byte RawSizeFieldNumber = 2;
-    public const byte ZLibDataFieldNumber = 3;
-    public const byte LzmaDataFieldNumber = 4;
-    [Obsolete("Bzip2 compression was deprecated in 2010.")]
-    public const byte Bzip2DataFieldNumber = 5;
-    public const byte Lz4DataFieldNumber = 6;
-    public const byte ZstdDataFieldNumber = 7;
-
-    public Blob(Memory<byte> source)
-    {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
-        {
-            switch (source.Span[memoryPosition++] >> 3)
-            {
-                case RawSizeFieldNumber:
-                    CompressionAlgorithm = CompressionAlgorithm.Raw;
-                    UncompressedSize = source.ReadUInt32(ref memoryPosition);
-                    continue;
-                case RawDataFieldNumber:
-                    CompressionAlgorithm = CompressionAlgorithm.Raw;
-                    break;
-                case ZLibDataFieldNumber:
-                    CompressionAlgorithm = CompressionAlgorithm.ZLib;
-                    break;
-                case LzmaDataFieldNumber:
-                    CompressionAlgorithm = CompressionAlgorithm.Lzma;
-                    break;
-                #pragma warning disable CS0618 // Type or member is obsolete
-                case Bzip2DataFieldNumber:
-                    CompressionAlgorithm = CompressionAlgorithm.Bzip2;
-                    break;
-                #pragma warning restore CS0618 // Type or member is obsolete
-                case Lz4DataFieldNumber:
-                    CompressionAlgorithm = CompressionAlgorithm.Lz4;
-                    break;
-                case ZstdDataFieldNumber:
-                    CompressionAlgorithm = CompressionAlgorithm.Zstd;
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in Blob message.");
+                return (uint)MessageData.Length;
             }
 
-            MessageData = source.ReadLengthDelimited(ref memoryPosition);
+            set => _uncompressedSize = value;
+        }
+
+        /// <summary>
+        /// The data in the message, it may be compressed or uncompressed.
+        /// </summary>
+        public Memory<byte> MessageData { get; set; }
+
+        public Memory<byte> GetUncompressedData(byte[] buffer)
+        {
+            switch (CompressionAlgorithm)
+            {
+                case CompressionAlgorithm.Raw:
+                    return MessageData;
+                case CompressionAlgorithm.ZLib:
+                    {
+                        ZLib zlib = new ZLib();
+                        ZStream zStream = new ZStream()
+                        {
+                            Input = MessageData.Span,
+                            Output = buffer
+                        };
+
+                        _ = zlib.InflateInit(ref zStream);
+                        _ = zlib.Inflate(ref zStream, ZLib.Z_SYNC_FLUSH);
+
+                        return buffer;
+                    }
+                case CompressionAlgorithm.Lzma:
+                case CompressionAlgorithm.Bzip2:
+                case CompressionAlgorithm.Lz4:
+                case CompressionAlgorithm.Zstd:
+                    throw new NotImplementedException("GetUncompressedData with buffer is only implemented for ZLib compressed blobs.");
+                default:
+                    throw new InvalidOperationException("Uncompressed data is not available for compressed blobs.");
+            }
+        }
+
+        internal CompressionAlgorithm CompressionAlgorithm { get; set; }
+
+        public const byte RawDataFieldNumber = 1;
+        public const byte RawSizeFieldNumber = 2;
+        public const byte ZLibDataFieldNumber = 3;
+        public const byte LzmaDataFieldNumber = 4;
+        [Obsolete("Bzip2 compression was deprecated in 2010.")]
+        public const byte Bzip2DataFieldNumber = 5;
+        public const byte Lz4DataFieldNumber = 6;
+        public const byte ZstdDataFieldNumber = 7;
+
+        public Blob(Memory<byte> source)
+        {
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
+            {
+                switch (source.Span[memoryPosition++] >> 3)
+                {
+                    case RawSizeFieldNumber:
+                        CompressionAlgorithm = CompressionAlgorithm.Raw;
+                        UncompressedSize = source.ReadUInt32(ref memoryPosition);
+                        continue;
+                    case RawDataFieldNumber:
+                        CompressionAlgorithm = CompressionAlgorithm.Raw;
+                        break;
+                    case ZLibDataFieldNumber:
+                        CompressionAlgorithm = CompressionAlgorithm.ZLib;
+                        break;
+                    case LzmaDataFieldNumber:
+                        CompressionAlgorithm = CompressionAlgorithm.Lzma;
+                        break;
+                    #pragma warning disable CS0618 // Type or member is obsolete
+                    case Bzip2DataFieldNumber:
+                        CompressionAlgorithm = CompressionAlgorithm.Bzip2;
+                        break;
+                    #pragma warning restore CS0618 // Type or member is obsolete
+                    case Lz4DataFieldNumber:
+                        CompressionAlgorithm = CompressionAlgorithm.Lz4;
+                        break;
+                    case ZstdDataFieldNumber:
+                        CompressionAlgorithm = CompressionAlgorithm.Zstd;
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in Blob message.");
+                }
+
+                MessageData = source.ReadLengthDelimited(ref memoryPosition);
+            }
         }
     }
-}
 
-internal enum CompressionAlgorithm
-{
-    Raw,
-    ZLib,
-    Lzma,
-    Bzip2,
-    Lz4,
-    Zstd
-}
-
-internal static class BlobMemoryExtensions
-{
-    internal static Blob AsBlob(this Memory<byte> source)
+    internal enum CompressionAlgorithm
     {
-        return new Blob(source);
+        Raw,
+        ZLib,
+        Lzma,
+        Bzip2,
+        Lz4,
+        Zstd
+    }
+
+    internal static class BlobMemoryExtensions
+    {
+        internal static Blob AsBlob(this Memory<byte> source)
+        {
+            return new Blob(source);
+        }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/BlobHeader.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/BlobHeader.cs
@@ -1,77 +1,79 @@
+using System;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class BlobHeader
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    /// <summary>
-    /// The type of data in the subsequent Blob.
-    /// </summary>
-    public string Type { get; init; } = string.Empty;
-
-    /// <summary>
-    /// Arbitrary blob that may include metadata about the following blob. For example, for OSM data, it might contain a
-    /// bounding box.
-    /// </summary>
-    /// <remarks>
-    /// This is a stub intended to enable the future design of indexed *.osm.pbf files.
-    /// </remarks>
-    public Memory<byte>? IndexData { get; init; }
-
-    /// <summary>
-    /// The serialized size of the subsequent Blob message.
-    /// </summary>
-    /// <remarks>
-    /// While the proto for the message is an int32, <see href="https://wiki.openstreetmap.org/wiki/PBF_Format">OSM PBF
-    /// Format</see> specifies that a Blob message must be less than 64 KiB, so the maximum value for this field is the
-    /// maximum value for a uint.
-    /// </remarks>
-    public uint DataSize { get; init; }
-
-    private const byte TypeFieldNumber = 1;
-    private const byte IndexDataFieldNumber = 2;
-    private const byte DataSizeFieldNumber = 3;
-
-    public BlobHeader(string type, Memory<byte> indexData, uint dataSize)
+    public class BlobHeader
     {
-        Type = type;
-        IndexData = indexData;
-        DataSize = dataSize;
-    }
+        /// <summary>
+        /// The type of data in the subsequent Blob.
+        /// </summary>
+        public string Type { get; set; } = string.Empty;
 
-    public BlobHeader(string type, uint dataSize)
-    {
-        Type = type;
-        DataSize = dataSize;
-    }
+        /// <summary>
+        /// Arbitrary blob that may include metadata about the following blob. For example, for OSM data, it might contain a
+        /// bounding box.
+        /// </summary>
+        /// <remarks>
+        /// This is a stub intended to enable the future design of indexed *.osm.pbf files.
+        /// </remarks>
+        public Memory<byte>? IndexData { get; set; }
 
-    internal BlobHeader(Memory<byte> source)
-    {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
+        /// <summary>
+        /// The serialized size of the subsequent Blob message.
+        /// </summary>
+        /// <remarks>
+        /// While the proto for the message is an int32, <see href="https://wiki.openstreetmap.org/wiki/PBF_Format">OSM PBF
+        /// Format</see> specifies that a Blob message must be less than 64 KiB, so the maximum value for this field is the
+        /// maximum value for a uint.
+        /// </remarks>
+        public uint DataSize { get; set; }
+
+        private const byte TypeFieldNumber = 1;
+        private const byte IndexDataFieldNumber = 2;
+        private const byte DataSizeFieldNumber = 3;
+
+        public BlobHeader(string type, Memory<byte> indexData, uint dataSize)
         {
-            switch (source.Span[memoryPosition++] >> 3)
+            Type = type;
+            IndexData = indexData;
+            DataSize = dataSize;
+        }
+
+        public BlobHeader(string type, uint dataSize)
+        {
+            Type = type;
+            DataSize = dataSize;
+        }
+
+        internal BlobHeader(Memory<byte> source)
+        {
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
             {
-                case TypeFieldNumber:
-                    Type = source.ReadLengthDelimited(ref memoryPosition).AsString();
-                    break;
-                case IndexDataFieldNumber:
-                    IndexData = source.ReadLengthDelimited(ref memoryPosition);
-                    break;
-                case DataSizeFieldNumber:
-                    DataSize = source.ReadVarInt(ref memoryPosition).AsUInt16();
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in BlobHeader message.");
+                switch (source.Span[memoryPosition++] >> 3)
+                {
+                    case TypeFieldNumber:
+                        Type = source.ReadLengthDelimited(ref memoryPosition).AsString();
+                        break;
+                    case IndexDataFieldNumber:
+                        IndexData = source.ReadLengthDelimited(ref memoryPosition);
+                        break;
+                    case DataSizeFieldNumber:
+                        DataSize = source.ReadVarInt(ref memoryPosition).AsUInt16();
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in BlobHeader message.");
+                }
             }
         }
     }
-}
 
-internal static class BlobHeaderMemoryExtensions
-{
-    internal static BlobHeader AsBlobHeader(this Memory<byte> source)
+    internal static class BlobHeaderMemoryExtensions
     {
-        return new BlobHeader(source);
+        internal static BlobHeader AsBlobHeader(this Memory<byte> source)
+        {
+            return new BlobHeader(source);
+        }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/ChangeSet.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/ChangeSet.cs
@@ -1,12 +1,14 @@
+using System;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-internal static class ChangeSetMemoryExtensions
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    internal static long AsChangeSet(this Memory<byte> source)
+    internal static class ChangeSetMemoryExtensions
     {
-        int memoryPosition = 0;
-        return source.ReadInt64(ref memoryPosition);
+        internal static long AsChangeSet(this Memory<byte> source)
+        {
+            int memoryPosition = 0;
+            return source.ReadInt64(ref memoryPosition);
+        }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/DenseInfo.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/DenseInfo.cs
@@ -1,149 +1,153 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class DenseInfo : IEquatable<DenseInfo>
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public List<int> Versions { get; init; } = [];
-    public List<long> Timestamps { get; init; } = [];
-    public List<long> ChangeSets { get; init; } = [];
-    public List<int> UserIds { get; init; } = [];
-    public List<int> UserStringIds { get; init; } = [];
-    /// <summary>
-    /// The visible flag is used to store history information. It indicates that the current object version has been
-    /// created by a delete operation on the OSM API.
-    /// <br />
-    /// If visible is set to false, this element has been deleted.
-    /// </summary>
-    public List<bool> IsVisibles { get; init; } = [];
-
-    public const byte VersionFieldNumber = 1;
-    public const byte TimestampFieldNumber = 2;
-    public const byte ChangeSetFieldNumber = 3;
-    public const byte UserIdFieldNumber = 4;
-    public const byte UserStringIdFieldNumber = 5;
-    public const byte IsVisibleFieldNumber = 6;
-
-    public bool Equals(DenseInfo? other)
+    public class DenseInfo : IEquatable<DenseInfo>
     {
-        if (other is null) return false;
+        public List<int> Versions { get; set; } = new List<int>();
+        public List<long> Timestamps { get; set; } = new List<long>();
+        public List<long> ChangeSets { get; set; } = new List<long>();
+        public List<int> UserIds { get; set; } = new List<int>();
+        public List<int> UserStringIds { get; set; } = new List<int>();
+        /// <summary>
+        /// The visible flag is used to store history information. It indicates that the current object version has been
+        /// created by a delete operation on the OSM API.
+        /// <br />
+        /// If visible is set to false, this element has been deleted.
+        /// </summary>
+        public List<bool> IsVisibles { get; set; } = new List<bool>();
 
-        return
-            Versions.SequenceEqual(other.Versions) &&
-            Timestamps.SequenceEqual(other.Timestamps) &&
-            ChangeSets.SequenceEqual(other.ChangeSets) &&
-            UserIds.SequenceEqual(other.UserIds) &&
-            UserStringIds.SequenceEqual(other.UserStringIds) &&
-            IsVisibles.SequenceEqual(other.IsVisibles);
-    }
+        public const byte VersionFieldNumber = 1;
+        public const byte TimestampFieldNumber = 2;
+        public const byte ChangeSetFieldNumber = 3;
+        public const byte UserIdFieldNumber = 4;
+        public const byte UserStringIdFieldNumber = 5;
+        public const byte IsVisibleFieldNumber = 6;
 
-    public override bool Equals(object? obj) => Equals(obj as DenseInfo);
-    public static bool operator ==(DenseInfo? left, DenseInfo? right) => Equals(left, right);
-    public static bool operator !=(DenseInfo? left, DenseInfo? right) => !Equals(left, right);
-
-    public override int GetHashCode()
-    {
-        HashCode hash = new();
-
-        foreach (var version in Versions)
-            hash.Add(version);
-
-        foreach (var timestamp in Timestamps)
-            hash.Add(timestamp);
-
-        foreach (var changeSet in ChangeSets)
-            hash.Add(changeSet);
-
-        foreach (var userId in UserIds)
-            hash.Add(userId);
-
-        foreach (var userStringId in UserStringIds)
-            hash.Add(userStringId);
-
-        foreach (var isVisible in IsVisibles)
-            hash.Add(isVisible);
-
-        return hash.ToHashCode();
-    }
-}
-
-internal static class DenseInfoMemoryExtensions
-{
-    internal static IEnumerable<Info> AsDenseInfo(this Memory<byte> source)
-    {
-        Memory<byte> versionBuffer = new();
-        Memory<byte> timestampBuffer = new();
-        Memory<byte> changeSetBuffer = new();
-        Memory<byte> userIdBuffer = new();
-        Memory<byte> userStringIdBuffer = new();
-        Memory<byte> isVisibleBuffer = new();
-
-        int versionPosition = 0;
-        int timestampPosition = 0;
-        int changeSetPosition = 0;
-        int userIdPosition = 0;
-        int userStringIdPosition = 0;
-        int isVisiblePosition = 0;
-
-        int memoryPosition = 0;
-        byte fieldDatatypeIdentifier;
-        int denseLength;
-        while (memoryPosition < source.Length)
+        public bool Equals(DenseInfo? other)
         {
-            fieldDatatypeIdentifier = source.Span[memoryPosition++];
-            denseLength = source.ReadInt32(ref memoryPosition);
+            if (other is null) return false;
 
-            switch (fieldDatatypeIdentifier >> 3)
-            {
-                case DenseInfo.VersionFieldNumber:
-                    versionBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseInfo.TimestampFieldNumber:
-                    timestampBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseInfo.ChangeSetFieldNumber:
-                    changeSetBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseInfo.UserIdFieldNumber:
-                    userIdBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseInfo.UserStringIdFieldNumber:
-                    userStringIdBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseInfo.IsVisibleFieldNumber:
-                    isVisibleBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unknown field number [{fieldDatatypeIdentifier >> 3}] in DenseInfo message.");
-            }
-
-            memoryPosition += denseLength;
+            return
+                Versions.SequenceEqual(other.Versions) &&
+                Timestamps.SequenceEqual(other.Timestamps) &&
+                ChangeSets.SequenceEqual(other.ChangeSets) &&
+                UserIds.SequenceEqual(other.UserIds) &&
+                UserStringIds.SequenceEqual(other.UserStringIds) &&
+                IsVisibles.SequenceEqual(other.IsVisibles);
         }
 
-        Info? previousInfo = null;
+        public override bool Equals(object? obj) => Equals(obj as DenseInfo);
+        public static bool operator ==(DenseInfo? left, DenseInfo? right) => Equals(left, right);
+        public static bool operator !=(DenseInfo? left, DenseInfo? right) => !Equals(left, right);
 
-        while
-        (
-            versionPosition < versionBuffer.Length ||
-            timestampPosition < timestampBuffer.Length ||
-            changeSetPosition < changeSetBuffer.Length ||
-            userIdPosition < userIdBuffer.Length ||
-            userStringIdPosition < userStringIdBuffer.Length ||
-            isVisiblePosition < isVisibleBuffer.Length
-        )
+        public override int GetHashCode()
         {
-            previousInfo = new Info
-            (
-                versionBuffer, ref versionPosition,
-                timestampBuffer, ref timestampPosition,
-                changeSetBuffer, ref changeSetPosition,
-                userIdBuffer, ref userIdPosition,
-                userStringIdBuffer, ref userStringIdPosition,
-                isVisibleBuffer, ref isVisiblePosition,
-                previousInfo
-            );
+            HashCode hash = new HashCode();
 
-            yield return previousInfo;
+            foreach (var version in Versions)
+                hash.Add(version);
+
+            foreach (var timestamp in Timestamps)
+                hash.Add(timestamp);
+
+            foreach (var changeSet in ChangeSets)
+                hash.Add(changeSet);
+
+            foreach (var userId in UserIds)
+                hash.Add(userId);
+
+            foreach (var userStringId in UserStringIds)
+                hash.Add(userStringId);
+
+            foreach (var isVisible in IsVisibles)
+                hash.Add(isVisible);
+
+            return hash.ToHashCode();
+        }
+    }
+
+    internal static class DenseInfoMemoryExtensions
+    {
+        internal static IEnumerable<Info> AsDenseInfo(this Memory<byte> source)
+        {
+            Memory<byte> versionBuffer = new Memory<byte>();
+            Memory<byte> timestampBuffer = new Memory<byte>();
+            Memory<byte> changeSetBuffer = new Memory<byte>();
+            Memory<byte> userIdBuffer = new Memory<byte>();
+            Memory<byte> userStringIdBuffer = new Memory<byte>();
+            Memory<byte> isVisibleBuffer = new Memory<byte>();
+
+            int versionPosition = 0;
+            int timestampPosition = 0;
+            int changeSetPosition = 0;
+            int userIdPosition = 0;
+            int userStringIdPosition = 0;
+            int isVisiblePosition = 0;
+
+            int memoryPosition = 0;
+            byte fieldDatatypeIdentifier;
+            int denseLength;
+            while (memoryPosition < source.Length)
+            {
+                fieldDatatypeIdentifier = source.Span[memoryPosition++];
+                denseLength = source.ReadInt32(ref memoryPosition);
+
+                switch (fieldDatatypeIdentifier >> 3)
+                {
+                    case DenseInfo.VersionFieldNumber:
+                        versionBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseInfo.TimestampFieldNumber:
+                        timestampBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseInfo.ChangeSetFieldNumber:
+                        changeSetBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseInfo.UserIdFieldNumber:
+                        userIdBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseInfo.UserStringIdFieldNumber:
+                        userStringIdBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseInfo.IsVisibleFieldNumber:
+                        isVisibleBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number [{fieldDatatypeIdentifier >> 3}] in DenseInfo message.");
+                }
+
+                memoryPosition += denseLength;
+            }
+
+            Info? previousInfo = null;
+
+            while
+            (
+                versionPosition < versionBuffer.Length ||
+                timestampPosition < timestampBuffer.Length ||
+                changeSetPosition < changeSetBuffer.Length ||
+                userIdPosition < userIdBuffer.Length ||
+                userStringIdPosition < userStringIdBuffer.Length ||
+                isVisiblePosition < isVisibleBuffer.Length
+            )
+            {
+                previousInfo = new Info
+                (
+                    versionBuffer, ref versionPosition,
+                    timestampBuffer, ref timestampPosition,
+                    changeSetBuffer, ref changeSetPosition,
+                    userIdBuffer, ref userIdPosition,
+                    userStringIdBuffer, ref userStringIdPosition,
+                    isVisibleBuffer, ref isVisiblePosition,
+                    previousInfo
+                );
+
+                yield return previousInfo;
+            }
         }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/DenseNodes.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/DenseNodes.cs
@@ -1,88 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class DenseNodes
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public const byte IdFieldNumber = 1;
-    public const byte DenseInfoFieldNumber = 5;
-    public const byte LatitudeFieldNumber = 8;
-    public const byte LongitudeFieldNumber = 9;
-    public const byte KeyValueFieldNumber = 10;
-}
-
-internal static class DenseNodesMemoryExtensions
-{
-    internal static IEnumerable<Node> AsDenseNodes(this Memory<byte> source)
+    public class DenseNodes
     {
-        Memory<byte> idBuffer = new();
-        Memory<byte> denseInfoBuffer = new();
-        Memory<byte> latitudeBuffer = new();
-        Memory<byte> longitudeBuffer = new();
-        Memory<byte> keyValueBuffer = new();
+        public const byte IdFieldNumber = 1;
+        public const byte DenseInfoFieldNumber = 5;
+        public const byte LatitudeFieldNumber = 8;
+        public const byte LongitudeFieldNumber = 9;
+        public const byte KeyValueFieldNumber = 10;
+    }
 
-        int memoryPosition = 0;
-        byte fieldDatatypeIdentifier;
-        int denseLength;
-
-        while (memoryPosition < source.Length)
+    internal static class DenseNodesMemoryExtensions
+    {
+        internal static IEnumerable<Node> AsDenseNodes(this Memory<byte> source)
         {
-            fieldDatatypeIdentifier = source.Span[memoryPosition++];
-            denseLength = source.ReadInt32(ref memoryPosition);
+            Memory<byte> idBuffer = new Memory<byte>();
+            Memory<byte> denseInfoBuffer = new Memory<byte>();
+            Memory<byte> latitudeBuffer = new Memory<byte>();
+            Memory<byte> longitudeBuffer = new Memory<byte>();
+            Memory<byte> keyValueBuffer = new Memory<byte>();
 
-            switch (fieldDatatypeIdentifier >> 3)
+            int memoryPosition = 0;
+            byte fieldDatatypeIdentifier;
+            int denseLength;
+
+            while (memoryPosition < source.Length)
             {
-                case DenseNodes.IdFieldNumber:
-                    idBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseNodes.DenseInfoFieldNumber:
-                    denseInfoBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseNodes.LatitudeFieldNumber:
-                    latitudeBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseNodes.LongitudeFieldNumber:
-                    longitudeBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                case DenseNodes.KeyValueFieldNumber:
-                    keyValueBuffer = source.Slice(memoryPosition, denseLength);
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unexpected field number {fieldDatatypeIdentifier >> 3} in DenseNodes.");
+                fieldDatatypeIdentifier = source.Span[memoryPosition++];
+                denseLength = source.ReadInt32(ref memoryPosition);
+
+                switch (fieldDatatypeIdentifier >> 3)
+                {
+                    case DenseNodes.IdFieldNumber:
+                        idBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseNodes.DenseInfoFieldNumber:
+                        denseInfoBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseNodes.LatitudeFieldNumber:
+                        latitudeBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseNodes.LongitudeFieldNumber:
+                        longitudeBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    case DenseNodes.KeyValueFieldNumber:
+                        keyValueBuffer = source.Slice(memoryPosition, denseLength);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unexpected field number {fieldDatatypeIdentifier >> 3} in DenseNodes.");
+                }
+
+                memoryPosition += denseLength;
             }
 
-            memoryPosition += denseLength;
-        }
+            int idPosition = 0;
+            int infoPosition = 0;
+            int latitudePosition = 0;
+            int longitudePosition = 0;
+            int keyValuePosition = 0;
 
-        int idPosition = 0;
-        int infoPosition = 0;
-        int latitudePosition = 0;
-        int longitudePosition = 0;
-        int keyValuePosition = 0;
+            Node? previousNode = null;
+            // TODO: This means the whole collection is materialized at once, what
+            //       if we instead did something like override operator+ so we could
+            //       read a dense info, then add the previous dense info to account
+            //       for the SInts? Doesn't have to be an operator overload, but
+            //       someway of updating the relative offsets.
+            Info[] infos = denseInfoBuffer.AsDenseInfo().ToArray();
 
-        Node? previousNode = null;
-        // TODO: This means the whole collection is materialized at once, what
-        //       if we instead did something like override operator+ so we could
-        //       read a dense info, then add the previous dense info to account
-        //       for the SInts? Doesn't have to be an operator overload, but
-        //       someway of updating the relative offsets.
-        Info[] infos = [.. denseInfoBuffer.AsDenseInfo()];
-
-        while (idPosition < idBuffer.Length)
-        {
-            List<(uint Key, uint Value)> keyValuePairs = keyValueBuffer.Length == 0 ? [] : keyValueBuffer.ReadKeyValuePairs(ref keyValuePosition);
-
-            previousNode = new()
+            while (idPosition < idBuffer.Length)
             {
-                Id = idBuffer.ReadSInt64(ref idPosition) + (previousNode?.Id ?? 0),
-                Info = infoPosition < infos.Length ? infos[infoPosition++] : null,
-                Latitude = latitudeBuffer.ReadSInt64(ref latitudePosition) + (previousNode?.Latitude ?? 0),
-                Longitude = longitudeBuffer.ReadSInt64(ref longitudePosition) + (previousNode?.Longitude ?? 0),
-                Keys = [.. keyValuePairs.Select(x => x.Key)],
-                Values = [.. keyValuePairs.Select(x => x.Value)],
-            };
+                List<(uint Key, uint Value)> keyValuePairs = keyValueBuffer.Length == 0 ? new List<(uint Key, uint Value)>() : keyValueBuffer.ReadKeyValuePairs(ref keyValuePosition);
 
-            yield return previousNode;
+                previousNode = new Node()
+                {
+                    Id = idBuffer.ReadSInt64(ref idPosition) + (previousNode?.Id ?? 0),
+                    Info = infoPosition < infos.Length ? infos[infoPosition++] : null,
+                    Latitude = latitudeBuffer.ReadSInt64(ref latitudePosition) + (previousNode?.Latitude ?? 0),
+                    Longitude = longitudeBuffer.ReadSInt64(ref longitudePosition) + (previousNode?.Longitude ?? 0),
+                    Keys = keyValuePairs.Select(x => x.Key).ToArray(),
+                    Values = keyValuePairs.Select(x => x.Value).ToArray(),
+                };
+
+                yield return previousNode;
+            }
         }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/HeaderBlock.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/HeaderBlock.cs
@@ -1,93 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class HeaderBlock : IEquatable<HeaderBlock>
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public HeaderBoundingBox? BoundingBox { get; init; }
-    public List<string>? RequiredFeatures { get; init; }
-    public List<string>? OptionalFeatures { get; init; }
-    public string? WritingProgram { get; init; }
-    public string? Source { get; init; }
-    public long? OsmosisReplicationTimestamp { get; init; }
-    public long? OsmosisReplicationSequenceNumber { get; init; }
-    public string? OsmosisReplicationBaseUrl { get; init; }
-
-    public const byte BoundingBoxFieldNumber = 1;
-    public const byte RequiredFeaturesFieldNumber = 4;
-    public const byte OptionalFeaturesFieldNumber = 5;
-    public const byte WritingProgramFieldNumber = 16;
-    public const byte SourceFieldNumber = 17;
-    public const byte OsmosisReplicationTimestampFieldNumber = 32;
-    public const byte OsmosisReplicationSequenceNumberFieldNumber = 33;
-    public const byte OsmosisReplicationBaseUrlFieldNumber = 34;
-
-    public HeaderBlock() { }
-
-    public HeaderBlock(Memory<byte> source)
+    public class HeaderBlock : IEquatable<HeaderBlock>
     {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
+        public HeaderBoundingBox? BoundingBox { get; set; }
+        public List<string>? RequiredFeatures { get; set; }
+        public List<string>? OptionalFeatures { get; set; }
+        public string? WritingProgram { get; set; }
+        public string? Source { get; set; }
+        public long? OsmosisReplicationTimestamp { get; set; }
+        public long? OsmosisReplicationSequenceNumber { get; set; }
+        public string? OsmosisReplicationBaseUrl { get; set; }
+
+        public const byte BoundingBoxFieldNumber = 1;
+        public const byte RequiredFeaturesFieldNumber = 4;
+        public const byte OptionalFeaturesFieldNumber = 5;
+        public const byte WritingProgramFieldNumber = 16;
+        public const byte SourceFieldNumber = 17;
+        public const byte OsmosisReplicationTimestampFieldNumber = 32;
+        public const byte OsmosisReplicationSequenceNumberFieldNumber = 33;
+        public const byte OsmosisReplicationBaseUrlFieldNumber = 34;
+
+        public HeaderBlock() { }
+
+        public HeaderBlock(Memory<byte> source)
         {
-            switch (source.ReadUInt16(ref memoryPosition) >> 3)
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
             {
-                case BoundingBoxFieldNumber:
-                    BoundingBox = source.ReadHeaderBoundingBox(ref memoryPosition);
-                    continue;
-                case RequiredFeaturesFieldNumber:
-                    RequiredFeatures ??= [];
-                    RequiredFeatures.Add(source.ReadString(ref memoryPosition));
-                    continue;
-                case OptionalFeaturesFieldNumber:
-                    OptionalFeatures ??= [];
-                    OptionalFeatures.Add(source.ReadString(ref memoryPosition));
-                    continue;
-                case WritingProgramFieldNumber:
-                    WritingProgram = source.ReadString(ref memoryPosition);
-                    continue;
-                case SourceFieldNumber:
-                    Source = source.ReadString(ref memoryPosition);
-                    continue;
-                case OsmosisReplicationTimestampFieldNumber:
-                    OsmosisReplicationTimestamp = source.ReadInt64(ref memoryPosition);
-                    continue;
-                case OsmosisReplicationSequenceNumberFieldNumber:
-                    OsmosisReplicationSequenceNumber = source.ReadInt64(ref memoryPosition);
-                    continue;
-                case OsmosisReplicationBaseUrlFieldNumber:
-                    OsmosisReplicationBaseUrl = source.ReadString(ref memoryPosition);
-                    continue;
-                default:
-                    throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in HeaderBlock message.");
+                switch (source.ReadUInt16(ref memoryPosition) >> 3)
+                {
+                    case BoundingBoxFieldNumber:
+                        BoundingBox = source.ReadHeaderBoundingBox(ref memoryPosition);
+                        continue;
+                    case RequiredFeaturesFieldNumber:
+                        RequiredFeatures ??= new List<string>();
+                        RequiredFeatures.Add(source.ReadString(ref memoryPosition));
+                        continue;
+                    case OptionalFeaturesFieldNumber:
+                        OptionalFeatures ??= new List<string>();
+                        OptionalFeatures.Add(source.ReadString(ref memoryPosition));
+                        continue;
+                    case WritingProgramFieldNumber:
+                        WritingProgram = source.ReadString(ref memoryPosition);
+                        continue;
+                    case SourceFieldNumber:
+                        Source = source.ReadString(ref memoryPosition);
+                        continue;
+                    case OsmosisReplicationTimestampFieldNumber:
+                        OsmosisReplicationTimestamp = source.ReadInt64(ref memoryPosition);
+                        continue;
+                    case OsmosisReplicationSequenceNumberFieldNumber:
+                        OsmosisReplicationSequenceNumber = source.ReadInt64(ref memoryPosition);
+                        continue;
+                    case OsmosisReplicationBaseUrlFieldNumber:
+                        OsmosisReplicationBaseUrl = source.ReadString(ref memoryPosition);
+                        continue;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in HeaderBlock message.");
+                }
             }
         }
+
+        public bool Equals(HeaderBlock? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            List<string> thisRequiredFeatures = RequiredFeatures ?? new List<string>();
+            List<string> otherRequiredFeatures = other.RequiredFeatures ?? new List<string>();
+
+            List<string> thisOptionalFeatures = OptionalFeatures ?? new List<string>();
+            List<string> otherOptionalFeatures = other.OptionalFeatures ?? new List<string>();
+
+            return
+                BoundingBox == other.BoundingBox &&
+                WritingProgram == other.WritingProgram &&
+                Source == other.Source &&
+                OsmosisReplicationTimestamp == other.OsmosisReplicationTimestamp &&
+                OsmosisReplicationSequenceNumber == other.OsmosisReplicationSequenceNumber &&
+                OsmosisReplicationBaseUrl == other.OsmosisReplicationBaseUrl &&
+                thisRequiredFeatures.SequenceEqual(otherRequiredFeatures) &&
+                thisOptionalFeatures.SequenceEqual(otherOptionalFeatures);
+        }
+        public static bool operator ==(HeaderBlock? left, HeaderBlock? right) => Equals(left, right);
+        public static bool operator !=(HeaderBlock? left, HeaderBlock? right) => !Equals(left, right);
+        public override bool Equals(object? obj) => Equals(obj as HeaderBlock);
+        public override int GetHashCode() => HashCode.Combine(BoundingBox, RequiredFeatures, OptionalFeatures, WritingProgram);
     }
 
-    public bool Equals(HeaderBlock? other)
+    internal static class HeaderBlockMemoryExtensions
     {
-        if (other is null) return false;
-        if (ReferenceEquals(this, other)) return true;
-
-        return
-            BoundingBox == other.BoundingBox &&
-            WritingProgram == other.WritingProgram &&
-            Source == other.Source &&
-            OsmosisReplicationTimestamp == other.OsmosisReplicationTimestamp &&
-            OsmosisReplicationSequenceNumber == other.OsmosisReplicationSequenceNumber &&
-            OsmosisReplicationBaseUrl == other.OsmosisReplicationBaseUrl &&
-            (RequiredFeatures ?? []).SequenceEqual(other.RequiredFeatures ?? []) &&
-            (OptionalFeatures ?? []).SequenceEqual(other.OptionalFeatures ?? []);
-    }
-    public static bool operator ==(HeaderBlock? left, HeaderBlock? right) => Equals(left, right);
-    public static bool operator !=(HeaderBlock? left, HeaderBlock? right) => !Equals(left, right);
-    public override bool Equals(object? obj) => Equals(obj as HeaderBlock);
-    public override int GetHashCode() => HashCode.Combine(BoundingBox, RequiredFeatures, OptionalFeatures, WritingProgram);
-}
-
-internal static class HeaderBlockMemoryExtensions
-{
-    internal static HeaderBlock AsHeaderBlock(this Memory<byte> source)
-    {
-        return new HeaderBlock(source);
+        internal static HeaderBlock AsHeaderBlock(this Memory<byte> source)
+        {
+            return new HeaderBlock(source);
+        }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/HeaderBoundingBox.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/HeaderBoundingBox.cs
@@ -1,72 +1,74 @@
+using System;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class HeaderBoundingBox : IEquatable<HeaderBoundingBox>
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public long Left { get; init; }
-    public long Right { get; init; }
-    public long Top { get; init; }
-    public long Bottom { get; init; }
-
-    public const byte LeftFieldNumber = 1;
-    public const byte RightFieldNumber = 2;
-    public const byte TopFieldNumber = 3;
-    public const byte BottomFieldNumber = 4;
-
-    public HeaderBoundingBox() { }
-
-    public HeaderBoundingBox(Memory<byte> source)
+    public class HeaderBoundingBox : IEquatable<HeaderBoundingBox>
     {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
+        public long Left { get; set; }
+        public long Right { get; set; }
+        public long Top { get; set; }
+        public long Bottom { get; set; }
+
+        public const byte LeftFieldNumber = 1;
+        public const byte RightFieldNumber = 2;
+        public const byte TopFieldNumber = 3;
+        public const byte BottomFieldNumber = 4;
+
+        public HeaderBoundingBox() { }
+
+        public HeaderBoundingBox(Memory<byte> source)
         {
-            switch (source.Span[memoryPosition++] >> 3)
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
             {
-                case LeftFieldNumber:
-                    Left = source.ReadVarInt(ref memoryPosition).AsSInt64();
-                    continue;
-                case RightFieldNumber:
-                    Right = source.ReadVarInt(ref memoryPosition).AsSInt64();
-                    continue;
-                case TopFieldNumber:
-                    Top = source.ReadVarInt(ref memoryPosition).AsSInt64();
-                    continue;
-                case BottomFieldNumber:
-                    Bottom = source.ReadVarInt(ref memoryPosition).AsSInt64();
-                    continue;
-                default:
-                    throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in HeaderBoundingBox message.");
+                switch (source.Span[memoryPosition++] >> 3)
+                {
+                    case LeftFieldNumber:
+                        Left = source.ReadVarInt(ref memoryPosition).AsSInt64();
+                        continue;
+                    case RightFieldNumber:
+                        Right = source.ReadVarInt(ref memoryPosition).AsSInt64();
+                        continue;
+                    case TopFieldNumber:
+                        Top = source.ReadVarInt(ref memoryPosition).AsSInt64();
+                        continue;
+                    case BottomFieldNumber:
+                        Bottom = source.ReadVarInt(ref memoryPosition).AsSInt64();
+                        continue;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in HeaderBoundingBox message.");
+                }
             }
         }
+
+        public override int GetHashCode() => HashCode.Combine(Left, Right, Top, Bottom);
+        public bool Equals(HeaderBoundingBox? other)
+        {
+            if (other is null) return false;
+            return Left == other.Left && Right == other.Right && Top == other.Top && Bottom == other.Bottom;
+        }
+        public override bool Equals(object? obj) => Equals(obj as HeaderBoundingBox);
+        public static bool operator ==(HeaderBoundingBox? left, HeaderBoundingBox? right) => left?.Equals(right) ?? right is null;
+        public static bool operator !=(HeaderBoundingBox? left, HeaderBoundingBox? right) => !(left == right);
     }
 
-    public override int GetHashCode() => HashCode.Combine(Left, Right, Top, Bottom);
-    public bool Equals(HeaderBoundingBox? other)
+    internal static class HeaderBoundingBoxMemoryExtensions
     {
-        if (other is null) return false;
-        return Left == other.Left && Right == other.Right && Top == other.Top && Bottom == other.Bottom;
-    }
-    public override bool Equals(object? obj) => Equals(obj as HeaderBoundingBox);
-    public static bool operator ==(HeaderBoundingBox? left, HeaderBoundingBox? right) => left?.Equals(right) ?? right is null;
-    public static bool operator !=(HeaderBoundingBox? left, HeaderBoundingBox? right) => !(left == right);
-}
+        internal static HeaderBoundingBox AsHeaderBoundingBox(this Memory<byte> source)
+        {
+            return new HeaderBoundingBox(source);
+        }
 
-internal static class HeaderBoundingBoxMemoryExtensions
-{
-    internal static HeaderBoundingBox AsHeaderBoundingBox(this Memory<byte> source)
-    {
-        return new HeaderBoundingBox(source);
-    }
+        internal static HeaderBoundingBox ReadHeaderBoundingBox(this Memory<byte> source, ref int memoryPosition)
+        {
+            var length = source.ReadUInt16(ref memoryPosition);
 
-    internal static HeaderBoundingBox ReadHeaderBoundingBox(this Memory<byte> source, ref int memoryPosition)
-    {
-        var length = source.ReadUInt16(ref memoryPosition);
+            var boundingBox = source.Slice(memoryPosition, length).AsHeaderBoundingBox();
 
-        var boundingBox = source.Slice(memoryPosition, length).AsHeaderBoundingBox();
+            memoryPosition += length;
 
-        memoryPosition += length;
-
-        return boundingBox;
+            return boundingBox;
+        }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/Info.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/Info.cs
@@ -1,129 +1,131 @@
+using System;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class Info : IEquatable<Info>
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public int Version { get; init; } = -1;
-    public long? Timestamp { get; init; }
-    public long? ChangeSet { get; init; }
-    public int? UserId { get; init; }
-    public int? UserStringId { get; init; }
-    /// <summary>
-    /// The visible flag is used to store history information. It indicates that the current object version has been
-    /// created by a delete operation on the OSM API.
-    /// <br />
-    /// If visible is set to false, this element has been deleted.
-    /// </summary>
-    public bool IsVisible { get; init; } = true;
-
-    public const byte VersionFieldNumber = 1;
-    public const byte TimestampFieldNumber = 2;
-    public const byte ChangeSetFieldNumber = 3;
-    public const byte UserIdFieldNumber = 4;
-    public const byte UserSecurityIdFieldNumber = 5;
-    public const byte IsVisibleFieldNumber = 6;
-
-    public Info() { }
-
-    public Info(Memory<byte> source)
+    public class Info : IEquatable<Info>
     {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
+        public int Version { get; set; } = -1;
+        public long? Timestamp { get; set; }
+        public long? ChangeSet { get; set; }
+        public int? UserId { get; set; }
+        public int? UserStringId { get; set; }
+        /// <summary>
+        /// The visible flag is used to store history information. It indicates that the current object version has been
+        /// created by a delete operation on the OSM API.
+        /// <br />
+        /// If visible is set to false, this element has been deleted.
+        /// </summary>
+        public bool IsVisible { get; set; } = true;
+
+        public const byte VersionFieldNumber = 1;
+        public const byte TimestampFieldNumber = 2;
+        public const byte ChangeSetFieldNumber = 3;
+        public const byte UserIdFieldNumber = 4;
+        public const byte UserSecurityIdFieldNumber = 5;
+        public const byte IsVisibleFieldNumber = 6;
+
+        public Info() { }
+
+        public Info(Memory<byte> source)
         {
-            switch (source.Span[memoryPosition++] >> 3)
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
             {
-                case VersionFieldNumber:
-                    Version = source.ReadInt32(ref memoryPosition);
-                    continue;
-                case TimestampFieldNumber:
-                    Timestamp = source.ReadInt64(ref memoryPosition);
-                    continue;
-                case ChangeSetFieldNumber:
-                    ChangeSet = source.ReadInt64(ref memoryPosition);
-                    continue;
-                case UserIdFieldNumber:
-                    UserId = source.ReadInt32(ref memoryPosition);
-                    continue;
-                case UserSecurityIdFieldNumber:
-                    UserStringId = source.ReadInt32(ref memoryPosition);
-                    continue;
-                case IsVisibleFieldNumber:
-                    IsVisible = source.ReadBool(ref memoryPosition);
-                    continue;
-                default:
-                    throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in Info message.");
+                switch (source.Span[memoryPosition++] >> 3)
+                {
+                    case VersionFieldNumber:
+                        Version = source.ReadInt32(ref memoryPosition);
+                        continue;
+                    case TimestampFieldNumber:
+                        Timestamp = source.ReadInt64(ref memoryPosition);
+                        continue;
+                    case ChangeSetFieldNumber:
+                        ChangeSet = source.ReadInt64(ref memoryPosition);
+                        continue;
+                    case UserIdFieldNumber:
+                        UserId = source.ReadInt32(ref memoryPosition);
+                        continue;
+                    case UserSecurityIdFieldNumber:
+                        UserStringId = source.ReadInt32(ref memoryPosition);
+                        continue;
+                    case IsVisibleFieldNumber:
+                        IsVisible = source.ReadBool(ref memoryPosition);
+                        continue;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in Info message.");
+                }
             }
         }
+
+        public Info
+        (
+            Memory<byte> versionSource, ref int versionMemoryPosition,
+            Memory<byte> timestampSource, ref int timestampMemoryPosition,
+            Memory<byte> changeSetSource, ref int changeSetMemoryPosition,
+            Memory<byte> userIdSource, ref int userIdMemoryPosition,
+            Memory<byte> userStringIdSource, ref int userStringIdMemoryPosition,
+            Memory<byte> isVisibleSource, ref int isVisibleMemoryPosition,
+            Info? previousInfo = null
+        )
+        {
+            if (versionMemoryPosition < versionSource.Length)
+            {
+                Version = versionSource.ReadInt32(ref versionMemoryPosition);
+            }
+            if (timestampMemoryPosition < timestampSource.Length)
+            {
+                Timestamp = timestampSource.ReadSInt64(ref timestampMemoryPosition) + (previousInfo?.Timestamp ?? 0);
+            }
+            if (changeSetMemoryPosition < changeSetSource.Length)
+            {
+                ChangeSet = changeSetSource.ReadSInt64(ref changeSetMemoryPosition) + (previousInfo?.ChangeSet ?? 0);
+            }
+            if (userIdMemoryPosition < userIdSource.Length)
+            {
+                UserId = userIdSource.ReadSInt32(ref userIdMemoryPosition) + (previousInfo?.UserId ?? 0);
+            }
+            if (userStringIdMemoryPosition < userStringIdSource.Length)
+            {
+                UserStringId = userStringIdSource.ReadSInt32(ref userStringIdMemoryPosition) + (previousInfo?.UserStringId ?? 0);
+            }
+            if (isVisibleMemoryPosition < isVisibleSource.Length)
+            {
+                IsVisible = isVisibleSource.ReadBool(ref isVisibleMemoryPosition);
+            }
+        }
+
+        public bool Equals(Info? other)
+        {
+            if (other is null) return false;
+            return Version == other.Version &&
+                Timestamp == other.Timestamp &&
+                ChangeSet == other.ChangeSet &&
+                UserId == other.UserId &&
+                UserStringId == other.UserStringId &&
+                IsVisible == other.IsVisible;
+        }
+        public override int GetHashCode()
+            => HashCode.Combine(Version, Timestamp, ChangeSet, UserId, UserStringId, IsVisible);
+        public static bool operator ==(Info? left, Info? right) => Equals(left, right);
+        public static bool operator !=(Info? left, Info? right) => !Equals(left, right);
+        public override bool Equals(object? obj) => Equals(obj as Info);
     }
 
-    public Info
-    (
-        Memory<byte> versionSource, ref int versionMemoryPosition,
-        Memory<byte> timestampSource, ref int timestampMemoryPosition,
-        Memory<byte> changeSetSource, ref int changeSetMemoryPosition,
-        Memory<byte> userIdSource, ref int userIdMemoryPosition,
-        Memory<byte> userStringIdSource, ref int userStringIdMemoryPosition,
-        Memory<byte> isVisibleSource, ref int isVisibleMemoryPosition,
-        Info? previousInfo = null
-    )
+    internal static class InfoMemoryExtensions
     {
-        if (versionMemoryPosition < versionSource.Length)
+        internal static Info AsInfo(this Memory<byte> source)
         {
-            Version = versionSource.ReadInt32(ref versionMemoryPosition);
+            return new Info(source);
         }
-        if (timestampMemoryPosition < timestampSource.Length)
-        {
-            Timestamp = timestampSource.ReadSInt64(ref timestampMemoryPosition) + (previousInfo?.Timestamp ?? 0);
-        }
-        if (changeSetMemoryPosition < changeSetSource.Length)
-        {
-            ChangeSet = changeSetSource.ReadSInt64(ref changeSetMemoryPosition) + (previousInfo?.ChangeSet ?? 0);
-        }
-        if (userIdMemoryPosition < userIdSource.Length)
-        {
-            UserId = userIdSource.ReadSInt32(ref userIdMemoryPosition) + (previousInfo?.UserId ?? 0);
-        }
-        if (userStringIdMemoryPosition < userStringIdSource.Length)
-        {
-            UserStringId = userStringIdSource.ReadSInt32(ref userStringIdMemoryPosition) + (previousInfo?.UserStringId ?? 0);
-        }
-        if (isVisibleMemoryPosition < isVisibleSource.Length)
-        {
-            IsVisible = isVisibleSource.ReadBool(ref isVisibleMemoryPosition);
-        }
-    }
 
-    public bool Equals(Info? other)
-    {
-        if (other is null) return false;
-        return Version == other.Version &&
-               Timestamp == other.Timestamp &&
-               ChangeSet == other.ChangeSet &&
-               UserId == other.UserId &&
-               UserStringId == other.UserStringId &&
-               IsVisible == other.IsVisible;
-    }
-    public override int GetHashCode()
-        => HashCode.Combine(Version, Timestamp, ChangeSet, UserId, UserStringId, IsVisible);
-    public static bool operator ==(Info? left, Info? right) => Equals(left, right);
-    public static bool operator !=(Info? left, Info? right) => !Equals(left, right);
-    public override bool Equals(object? obj) => Equals(obj as Info);
-}
+        internal static Info ReadInfo(this Memory<byte> source, ref int memoryPosition)
+        {
+            var infoLength = source.ReadUInt16(ref memoryPosition);
+            var info = source.Slice(memoryPosition, infoLength).AsInfo();
+            memoryPosition += infoLength;
 
-internal static class InfoMemoryExtensions
-{
-    internal static Info AsInfo(this Memory<byte> source)
-    {
-        return new Info(source);
-    }
-
-    internal static Info ReadInfo(this Memory<byte> source, ref int memoryPosition)
-    {
-        var infoLength = source.ReadUInt16(ref memoryPosition);
-        var info = source.Slice(memoryPosition, infoLength).AsInfo();
-        memoryPosition += infoLength;
-
-        return info;
+            return info;
+        }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/Node.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/Node.cs
@@ -1,91 +1,94 @@
+using System;
+using System.Linq;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class Node : IEquatable<Node>
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public long Id { get; init; }
-    public uint[] Keys { get; init; } = [];
-    public uint[] Values { get; init; } = [];
-    public Info? Info { get; init; }
-    public long Latitude { get; init; }
-    public long Longitude { get; init; }
-
-    public const byte IdFieldNumber = 1;
-    public const byte KeysFieldNumber = 2;
-    public const byte ValuesFieldNumber = 3;
-    public const byte InfoFieldNumber = 4;
-    public const byte LatitudeFieldNumber = 8;
-    public const byte LongitudeFieldNumber = 9;
-
-    public Node() { }
-
-    public Node(Memory<byte> source)
+    public class Node : IEquatable<Node>
     {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
+        public long Id { get; set; }
+        public uint[] Keys { get; set; } = Array.Empty<uint>();
+        public uint[] Values { get; set; } = Array.Empty<uint>();
+        public Info? Info { get; set; }
+        public long Latitude { get; set; }
+        public long Longitude { get; set; }
+
+        public const byte IdFieldNumber = 1;
+        public const byte KeysFieldNumber = 2;
+        public const byte ValuesFieldNumber = 3;
+        public const byte InfoFieldNumber = 4;
+        public const byte LatitudeFieldNumber = 8;
+        public const byte LongitudeFieldNumber = 9;
+
+        public Node() { }
+
+        public Node(Memory<byte> source)
         {
-            switch (source.Span[memoryPosition++] >> 3)
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
             {
-                case IdFieldNumber:
-                    Id = source.ReadInt64(ref memoryPosition);
-                    continue;
-                case KeysFieldNumber:
-                    Keys = [.. source.ReadPackedUInt32(ref memoryPosition)];
-                    continue;
-                case ValuesFieldNumber:
-                    Values = [.. source.ReadPackedUInt32(ref memoryPosition)];
-                    continue;
-                case InfoFieldNumber:
-                    Info = source.ReadInfo(ref memoryPosition);
-                    continue;
-                case LatitudeFieldNumber:
-                    Latitude = source.ReadSInt64(ref memoryPosition);
-                    continue;
-                case LongitudeFieldNumber:
-                    Longitude = source.ReadSInt64(ref memoryPosition);
-                    continue;
-                default:
-                    throw new InvalidOperationException($"Unknown field number {source.Span[memoryPosition - 1] >> 3} encountered while reading Node from memory.");
+                switch (source.Span[memoryPosition++] >> 3)
+                {
+                    case IdFieldNumber:
+                        Id = source.ReadInt64(ref memoryPosition);
+                        continue;
+                    case KeysFieldNumber:
+                        Keys = source.ReadPackedUInt32(ref memoryPosition).ToArray();
+                        continue;
+                    case ValuesFieldNumber:
+                        Values = source.ReadPackedUInt32(ref memoryPosition).ToArray();
+                        continue;
+                    case InfoFieldNumber:
+                        Info = source.ReadInfo(ref memoryPosition);
+                        continue;
+                    case LatitudeFieldNumber:
+                        Latitude = source.ReadSInt64(ref memoryPosition);
+                        continue;
+                    case LongitudeFieldNumber:
+                        Longitude = source.ReadSInt64(ref memoryPosition);
+                        continue;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number {source.Span[memoryPosition - 1] >> 3} encountered while reading Node from memory.");
+                }
             }
         }
+
+        public bool Equals(Node? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Id == other.Id &&
+                Keys.SequenceEqual(other.Keys) &&
+                Values.SequenceEqual(other.Values) &&
+                (Info?.Equals(other.Info) ?? other.Info is null) &&
+                Latitude == other.Latitude &&
+                Longitude == other.Longitude;
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(Id);
+            foreach (var key in Keys)
+                hash.Add(key);
+            foreach (var value in Values)
+                hash.Add(value);
+            hash.Add(Info);
+            hash.Add(Latitude);
+            hash.Add(Longitude);
+            return hash.ToHashCode();
+        }
+        public static bool operator ==(Node? left, Node? right) => left?.Equals(right) ?? right is null;
+        public static bool operator !=(Node? left, Node? right) => !(left?.Equals(right) ?? right is null);
+        public override bool Equals(object? obj) => Equals(obj as Node);
     }
 
-    public bool Equals(Node? other)
+    internal static class NodeMemoryExtensions
     {
-        if (other is null) return false;
-        if (ReferenceEquals(this, other)) return true;
-
-        return Id == other.Id &&
-               Keys.SequenceEqual(other.Keys) &&
-               Values.SequenceEqual(other.Values) &&
-               (Info?.Equals(other.Info) ?? other.Info is null) &&
-               Latitude == other.Latitude &&
-               Longitude == other.Longitude;
-    }
-
-    public override int GetHashCode()
-    {
-        var hash = new HashCode();
-        hash.Add(Id);
-        foreach (var key in Keys)
-            hash.Add(key);
-        foreach (var value in Values)
-            hash.Add(value);
-        hash.Add(Info);
-        hash.Add(Latitude);
-        hash.Add(Longitude);
-        return hash.ToHashCode();
-    }
-    public static bool operator ==(Node? left, Node? right) => left?.Equals(right) ?? right is null;
-    public static bool operator !=(Node? left, Node? right) => !(left?.Equals(right) ?? right is null);
-    public override bool Equals(object? obj) => Equals(obj as Node);
-}
-
-internal static class NodeMemoryExtensions
-{
-    internal static Node AsNode(this Memory<byte> source)
-    {
-        return new Node(source);
+        internal static Node AsNode(this Memory<byte> source)
+        {
+            return new Node(source);
+        }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/PrimitiveGroup.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/PrimitiveGroup.cs
@@ -1,146 +1,149 @@
+using System;
+using System.Collections.Generic;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class PrimitiveGroup : IEquatable<PrimitiveGroup>
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public List<Node> Nodes { get; init; } = [];
-    public List<Way> Ways { get; init; } = [];
-    public List<Relation> Relations { get; init; } = [];
-    public List<long> ChangeSets { get; init; } = [];
-
-    public const byte NodesFieldNumber = 1;
-    public const byte DenseNodesFieldNumber = 2;
-    public const byte WaysFieldNumber = 3;
-    public const byte RelationsFieldNumber = 4;
-    public const byte ChangeSetsFieldNumber = 5;
-
-    public bool Equals(PrimitiveGroup? other)
+    public class PrimitiveGroup : IEquatable<PrimitiveGroup>
     {
-        if (other is null) return false;
-        if (ReferenceEquals(this, other)) return true;
+        public List<Node> Nodes { get; set; } = new List<Node>();
+        public List<Way> Ways { get; set; } = new List<Way>();
+        public List<Relation> Relations { get; set; } = new List<Relation>();
+        public List<long> ChangeSets { get; set; } = new List<long>();
 
-        if ((Nodes.Count != other.Nodes.Count) ||
-            (Ways.Count != other.Ways.Count) ||
-            (Relations.Count != other.Relations.Count) ||
-            (ChangeSets.Count != other.ChangeSets.Count))
+        public const byte NodesFieldNumber = 1;
+        public const byte DenseNodesFieldNumber = 2;
+        public const byte WaysFieldNumber = 3;
+        public const byte RelationsFieldNumber = 4;
+        public const byte ChangeSetsFieldNumber = 5;
+
+        public bool Equals(PrimitiveGroup? other)
         {
-            return false;
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            if ((Nodes.Count != other.Nodes.Count) ||
+                (Ways.Count != other.Ways.Count) ||
+                (Relations.Count != other.Relations.Count) ||
+                (ChangeSets.Count != other.ChangeSets.Count))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Nodes.Count; ++i)
+            {
+                if (Nodes[i] != other.Nodes[i]) return false;
+            }
+
+            for (int i = 0; i < Ways.Count; ++i)
+            {
+                if (Ways[i] != other.Ways[i]) return false;
+            }
+
+            for (int i = 0; i < Relations.Count; ++i)
+            {
+                if (Relations[i] != other.Relations[i]) return false;
+            }
+
+            for (int i = 0; i < ChangeSets.Count; ++i)
+            {
+                if (ChangeSets[i] != other.ChangeSets[i]) return false;
+            }
+
+            return true;
         }
 
-        for (int i = 0; i < Nodes.Count; ++i)
+        public override int GetHashCode()
         {
-            if (Nodes[i] != other.Nodes[i]) return false;
+            var hash = new HashCode();
+            foreach (var node in Nodes)
+                hash.Add(node);
+            foreach (var ways in Ways)
+                hash.Add(ways);
+            foreach (var relations in Relations)
+                hash.Add(relations);
+            foreach (var changeSet in ChangeSets)
+                hash.Add(changeSet);
+            return hash.ToHashCode();
         }
-
-        for (int i = 0; i < Ways.Count; ++i)
-        {
-            if (Ways[i] != other.Ways[i]) return false;
-        }
-
-        for (int i = 0; i < Relations.Count; ++i)
-        {
-            if (Relations[i] != other.Relations[i]) return false;
-        }
-
-        for (int i = 0; i < ChangeSets.Count; ++i)
-        {
-            if (ChangeSets[i] != other.ChangeSets[i]) return false;
-        }
-
-        return true;
+        public static bool operator ==(PrimitiveGroup? left, PrimitiveGroup? right) => left?.Equals(right) ?? right is null;
+        public static bool operator !=(PrimitiveGroup? left, PrimitiveGroup? right) => !(left?.Equals(right) ?? right is null);
+        public override bool Equals(object? obj) => Equals(obj as PrimitiveGroup);
     }
 
-    public override int GetHashCode()
-    {
-        var hash = new HashCode();
-        foreach (var node in Nodes)
-            hash.Add(node);
-        foreach (var ways in Ways)
-            hash.Add(ways);
-        foreach (var relations in Relations)
-            hash.Add(relations);
-        foreach (var changeSet in ChangeSets)
-            hash.Add(changeSet);
-        return hash.ToHashCode();
-    }
-    public static bool operator ==(PrimitiveGroup? left, PrimitiveGroup? right) => left?.Equals(right) ?? right is null;
-    public static bool operator !=(PrimitiveGroup? left, PrimitiveGroup? right) => !(left?.Equals(right) ?? right is null);
-    public override bool Equals(object? obj) => Equals(obj as PrimitiveGroup);
+    // internal static class PrimitiveGroupMemoryExtensions
+    // {
+    //     internal static IEnumerable<Node> AsDenseNodes(this Memory<byte> source)
+    //     {
+    //         Memory<byte> idBuffer = new();
+    //         Memory<byte> denseInfoBuffer = new();
+    //         Memory<byte> latitudeBuffer = new();
+    //         Memory<byte> longitudeBuffer = new();
+    //         Memory<byte> keyValueBuffer = new();
+
+    //         int memoryPosition = 0;
+    //         byte fieldDatatypeIdentifier;
+    //         int denseLength;
+
+    //         while (memoryPosition < source.Length)
+    //         {
+    //             fieldDatatypeIdentifier = source.Span[memoryPosition++];
+    //             denseLength = source.ReadInt32(ref memoryPosition);
+
+    //             switch (fieldDatatypeIdentifier >> 3)
+    //             {
+    //                 case DenseNodes.IdFieldNumber:
+    //                     idBuffer = source.Slice(memoryPosition, denseLength);
+    //                     break;
+    //                 case DenseNodes.DenseInfoFieldNumber:
+    //                     denseInfoBuffer = source.Slice(memoryPosition, denseLength);
+    //                     break;
+    //                 case DenseNodes.LatitudeFieldNumber:
+    //                     latitudeBuffer = source.Slice(memoryPosition, denseLength);
+    //                     break;
+    //                 case DenseNodes.LongitudeFieldNumber:
+    //                     longitudeBuffer = source.Slice(memoryPosition, denseLength);
+    //                     break;
+    //                 case DenseNodes.KeyValueFieldNumber:
+    //                     keyValueBuffer = source.Slice(memoryPosition, denseLength);
+    //                     break;
+    //                 default:
+    //                     throw new InvalidOperationException($"Unexpected field number {fieldDatatypeIdentifier >> 3} in DenseNodes.");
+    //             }
+
+    //             memoryPosition += denseLength;
+    //         }
+
+    //         int idPosition = 0;
+    //         int infoPosition = 0;
+    //         int latitudePosition = 0;
+    //         int longitudePosition = 0;
+    //         int keyValuePosition = 0;
+
+    //         Node? previousNode = null;
+    //         // TODO: This means the whole collection is materialized at once, what
+    //         //       if we instead did something like override operator+ so we could
+    //         //       read a dense info, then add the previous dense info to account
+    //         //       for the SInts? Doesn't have to be an operator overload, but
+    //         //       someway of updating the relative offsets.
+    //         Info[] infos = [.. denseInfoBuffer.AsDenseInfo()];
+
+    //         while (idPosition < idBuffer.Length)
+    //         {
+    //             List<(uint Key, uint Value)> keyValuePairs = keyValueBuffer.Length == 0 ? [] : keyValueBuffer.ReadKeyValuePairs(ref keyValuePosition);
+
+    //             previousNode = new()
+    //             {
+    //                 Id = idBuffer.ReadSInt64(ref idPosition) + (previousNode?.Id ?? 0),
+    //                 Info = infoPosition < infos.Length ? infos[infoPosition++] : null,
+    //                 Latitude = latitudeBuffer.ReadSInt64(ref latitudePosition) + (previousNode?.Latitude ?? 0),
+    //                 Longitude = longitudeBuffer.ReadSInt64(ref longitudePosition) + (previousNode?.Longitude ?? 0),
+    //                 Keys = [.. keyValuePairs.Select(x => x.Key)],
+    //                 Values = [.. keyValuePairs.Select(x => x.Value)],
+    //             };
+
+    //             yield return previousNode;
+    //         }
+    //     }
+    // }
 }
-
-// internal static class PrimitiveGroupMemoryExtensions
-// {
-//     internal static IEnumerable<Node> AsDenseNodes(this Memory<byte> source)
-//     {
-//         Memory<byte> idBuffer = new();
-//         Memory<byte> denseInfoBuffer = new();
-//         Memory<byte> latitudeBuffer = new();
-//         Memory<byte> longitudeBuffer = new();
-//         Memory<byte> keyValueBuffer = new();
-
-//         int memoryPosition = 0;
-//         byte fieldDatatypeIdentifier;
-//         int denseLength;
-
-//         while (memoryPosition < source.Length)
-//         {
-//             fieldDatatypeIdentifier = source.Span[memoryPosition++];
-//             denseLength = source.ReadInt32(ref memoryPosition);
-
-//             switch (fieldDatatypeIdentifier >> 3)
-//             {
-//                 case DenseNodes.IdFieldNumber:
-//                     idBuffer = source.Slice(memoryPosition, denseLength);
-//                     break;
-//                 case DenseNodes.DenseInfoFieldNumber:
-//                     denseInfoBuffer = source.Slice(memoryPosition, denseLength);
-//                     break;
-//                 case DenseNodes.LatitudeFieldNumber:
-//                     latitudeBuffer = source.Slice(memoryPosition, denseLength);
-//                     break;
-//                 case DenseNodes.LongitudeFieldNumber:
-//                     longitudeBuffer = source.Slice(memoryPosition, denseLength);
-//                     break;
-//                 case DenseNodes.KeyValueFieldNumber:
-//                     keyValueBuffer = source.Slice(memoryPosition, denseLength);
-//                     break;
-//                 default:
-//                     throw new InvalidOperationException($"Unexpected field number {fieldDatatypeIdentifier >> 3} in DenseNodes.");
-//             }
-
-//             memoryPosition += denseLength;
-//         }
-
-//         int idPosition = 0;
-//         int infoPosition = 0;
-//         int latitudePosition = 0;
-//         int longitudePosition = 0;
-//         int keyValuePosition = 0;
-
-//         Node? previousNode = null;
-//         // TODO: This means the whole collection is materialized at once, what
-//         //       if we instead did something like override operator+ so we could
-//         //       read a dense info, then add the previous dense info to account
-//         //       for the SInts? Doesn't have to be an operator overload, but
-//         //       someway of updating the relative offsets.
-//         Info[] infos = [.. denseInfoBuffer.AsDenseInfo()];
-
-//         while (idPosition < idBuffer.Length)
-//         {
-//             List<(uint Key, uint Value)> keyValuePairs = keyValueBuffer.Length == 0 ? [] : keyValueBuffer.ReadKeyValuePairs(ref keyValuePosition);
-
-//             previousNode = new()
-//             {
-//                 Id = idBuffer.ReadSInt64(ref idPosition) + (previousNode?.Id ?? 0),
-//                 Info = infoPosition < infos.Length ? infos[infoPosition++] : null,
-//                 Latitude = latitudeBuffer.ReadSInt64(ref latitudePosition) + (previousNode?.Latitude ?? 0),
-//                 Longitude = longitudeBuffer.ReadSInt64(ref longitudePosition) + (previousNode?.Longitude ?? 0),
-//                 Keys = [.. keyValuePairs.Select(x => x.Key)],
-//                 Values = [.. keyValuePairs.Select(x => x.Value)],
-//             };
-
-//             yield return previousNode;
-//         }
-//     }
-// }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/Relation.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/Relation.cs
@@ -1,114 +1,117 @@
+using System;
+using System.Linq;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class Relation : IEquatable<Relation>
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public long Id { get; init; }
-    public uint[] Keys { get; init; } = [];
-    public uint[] Values { get; init; } = [];
-    public Info? Info { get; init; }
-    public int[] RoleStringIds { get; init; } = [];
-    public long[] MemberIds { get; init; } = [];
-    public MemberType[] MemberTypes { get; init; } = [];
-
-    public const byte IdFieldNumber = 1;
-    public const byte KeysFieldNumber = 2;
-    public const byte ValuesFieldNumber = 3;
-    public const byte InfoFieldNumber = 4;
-    public const byte RoleStringIdsFieldNumber = 8;
-    public const byte MemberIdsFieldNumber = 9;
-    public const byte MemberTypesFieldNumber = 10;
-
-    public enum MemberType
+    public class Relation : IEquatable<Relation>
     {
-        Node = 0,
-        Way = 1,
-        Relation = 2,
-    }
+        public long Id { get; set; }
+        public uint[] Keys { get; set; } = Array.Empty<uint>();
+        public uint[] Values { get; set; } = Array.Empty<uint>();
+        public Info? Info { get; set; }
+        public int[] RoleStringIds { get; set; } = Array.Empty<int>();
+        public long[] MemberIds { get; set; } = Array.Empty<long>();
+        public MemberType[] MemberTypes { get; set; } = Array.Empty<MemberType>();
 
-    public Relation() { }
+        public const byte IdFieldNumber = 1;
+        public const byte KeysFieldNumber = 2;
+        public const byte ValuesFieldNumber = 3;
+        public const byte InfoFieldNumber = 4;
+        public const byte RoleStringIdsFieldNumber = 8;
+        public const byte MemberIdsFieldNumber = 9;
+        public const byte MemberTypesFieldNumber = 10;
 
-    public Relation(Memory<byte> source)
-    {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
+        public enum MemberType
         {
-            switch (source.Span[memoryPosition++] >> 3)
+            Node = 0,
+            Way = 1,
+            Relation = 2,
+        }
+
+        public Relation() { }
+
+        public Relation(Memory<byte> source)
+        {
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
             {
-                case IdFieldNumber:
-                    Id = source.ReadInt64(ref memoryPosition);
-                    continue;
-                case KeysFieldNumber:
-                    Keys = [.. source.ReadPackedUInt32(ref memoryPosition)];
-                    continue;
-                case ValuesFieldNumber:
-                    Values = [.. source.ReadPackedUInt32(ref memoryPosition)];
-                    continue;
-                case InfoFieldNumber:
-                    Info = source.ReadInfo(ref memoryPosition);
-                    continue;
-                case RoleStringIdsFieldNumber:
-                    RoleStringIds = [.. source.ReadPackedInt32(ref memoryPosition)];
-                    continue;
-                case MemberIdsFieldNumber:
-                    MemberIds = [.. source.ReadPackedDeltaCodedSInt64(ref memoryPosition)];
-                    continue;
-                case MemberTypesFieldNumber:
-                    MemberTypes = [.. source.ReadPackedEnum<MemberType>(ref memoryPosition)];
-                    continue;
-                default:
-                    throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in Relation message.");
+                switch (source.Span[memoryPosition++] >> 3)
+                {
+                    case IdFieldNumber:
+                        Id = source.ReadInt64(ref memoryPosition);
+                        continue;
+                    case KeysFieldNumber:
+                        Keys = source.ReadPackedUInt32(ref memoryPosition).ToArray();
+                        continue;
+                    case ValuesFieldNumber:
+                        Values = source.ReadPackedUInt32(ref memoryPosition).ToArray();
+                        continue;
+                    case InfoFieldNumber:
+                        Info = source.ReadInfo(ref memoryPosition);
+                        continue;
+                    case RoleStringIdsFieldNumber:
+                        RoleStringIds = source.ReadPackedInt32(ref memoryPosition).ToArray();
+                        continue;
+                    case MemberIdsFieldNumber:
+                        MemberIds = source.ReadPackedDeltaCodedSInt64(ref memoryPosition).ToArray();
+                        continue;
+                    case MemberTypesFieldNumber:
+                        MemberTypes = source.ReadPackedEnum<MemberType>(ref memoryPosition).ToArray();
+                        continue;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in Relation message.");
+                }
             }
         }
-    }
 
-    public bool Equals(Relation? other)
-    {
-        if (other is null) return false;
-        if (ReferenceEquals(this, other)) return true;
-
-        return Id == other.Id &&
-               Keys.SequenceEqual(other.Keys) &&
-               Values.SequenceEqual(other.Values) &&
-               Info == other.Info &&
-               RoleStringIds.SequenceEqual(other.RoleStringIds) &&
-               MemberIds.SequenceEqual(other.MemberIds) &&
-               MemberTypes.SequenceEqual(other.MemberTypes);
-    }
-
-    public override bool Equals(object? obj) => Equals(obj as Relation);
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(
-            Id,
-            GetArrayHashCode(Keys),
-            GetArrayHashCode(Values),
-            Info,
-            GetArrayHashCode(RoleStringIds),
-            GetArrayHashCode(MemberIds),
-            GetArrayHashCode(MemberTypes)
-        );
-    }
-    private static int GetArrayHashCode<T>(T[]? array)
-    {
-        if (array is null)
-            return 0;
-        var hash = new HashCode();
-        foreach (var item in array)
+        public bool Equals(Relation? other)
         {
-            hash.Add(item);
-        }
-        return hash.ToHashCode();
-    }
-    public static bool operator ==(Relation left, Relation right) => left?.Equals(right) ?? right is null;
-    public static bool operator !=(Relation left, Relation right) => !(left == right);
-}
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
 
-internal static class RelationMemoryExtensions
-{
-    internal static Relation AsRelation(this Memory<byte> source)
+            return Id == other.Id &&
+                Keys.SequenceEqual(other.Keys) &&
+                Values.SequenceEqual(other.Values) &&
+                Info == other.Info &&
+                RoleStringIds.SequenceEqual(other.RoleStringIds) &&
+                MemberIds.SequenceEqual(other.MemberIds) &&
+                MemberTypes.SequenceEqual(other.MemberTypes);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as Relation);
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Id,
+                GetArrayHashCode(Keys),
+                GetArrayHashCode(Values),
+                Info,
+                GetArrayHashCode(RoleStringIds),
+                GetArrayHashCode(MemberIds),
+                GetArrayHashCode(MemberTypes)
+            );
+        }
+        private static int GetArrayHashCode<T>(T[]? array)
+        {
+            if (array is null)
+                return 0;
+            var hash = new HashCode();
+            foreach (var item in array)
+            {
+                hash.Add(item);
+            }
+            return hash.ToHashCode();
+        }
+        public static bool operator ==(Relation left, Relation right) => left?.Equals(right) ?? right is null;
+        public static bool operator !=(Relation left, Relation right) => !(left == right);
+    }
+
+    internal static class RelationMemoryExtensions
     {
-        return new Relation(source);
+        internal static Relation AsRelation(this Memory<byte> source)
+        {
+            return new Relation(source);
+        }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/StringTable.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/StringTable.cs
@@ -1,17 +1,20 @@
+using System;
+using System.Collections.Generic;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-internal static class StringTableMemoryExtensions
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    internal static IEnumerable<string?> AsStringTable(this Memory<byte> source)
+    internal static class StringTableMemoryExtensions
     {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
+        internal static IEnumerable<string?> AsStringTable(this Memory<byte> source)
         {
-            ++memoryPosition;
-            var temp = source.ReadNullableString(ref memoryPosition);
-            yield return temp;
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
+            {
+                ++memoryPosition;
+                var temp = source.ReadNullableString(ref memoryPosition);
+                yield return temp;
+            }
         }
     }
 }

--- a/src/Mittons.Mapping/Protobuf/Messages/Osm/Way.cs
+++ b/src/Mittons.Mapping/Protobuf/Messages/Osm/Way.cs
@@ -1,107 +1,110 @@
+using System;
+using System.Linq;
 using Mittons.Mapping.Extensions;
 
-namespace Mittons.Mapping.Protobuf.Messages.Osm;
-
-public class Way : IEquatable<Way>
+namespace Mittons.Mapping.Protobuf.Messages.Osm
 {
-    public long Id { get; init; } = -1;
-    public uint[]? Keys { get; init; }
-    public uint[]? Values { get; init; }
-    public Info? Info { get; init; }
-    public long[]? References { get; init; }
-    public long[]? Latitudes { get; init; }
-    public long[]? Longitudes { get; init; }
-
-    public const byte IdFieldNumber = 1;
-    public const byte KeySegmentsFieldNumber = 2;
-    public const byte ValuesFieldNumber = 3;
-    public const byte InfoFieldNumber = 4;
-    public const byte ReferencesFieldNumber = 8;
-    public const byte LatitudesFieldNumber = 9;
-    public const byte LongitudesFieldNumber = 10;
-
-    public Way() { }
-
-    public Way(Memory<byte> source)
+    public class Way : IEquatable<Way>
     {
-        int memoryPosition = 0;
-        while (memoryPosition < source.Length)
+        public long Id { get; set; } = -1;
+        public uint[]? Keys { get; set; }
+        public uint[]? Values { get; set; }
+        public Info? Info { get; set; }
+        public long[]? References { get; set; }
+        public long[]? Latitudes { get; set; }
+        public long[]? Longitudes { get; set; }
+
+        public const byte IdFieldNumber = 1;
+        public const byte KeySegmentsFieldNumber = 2;
+        public const byte ValuesFieldNumber = 3;
+        public const byte InfoFieldNumber = 4;
+        public const byte ReferencesFieldNumber = 8;
+        public const byte LatitudesFieldNumber = 9;
+        public const byte LongitudesFieldNumber = 10;
+
+        public Way() { }
+
+        public Way(Memory<byte> source)
         {
-            switch (source.Span[memoryPosition++] >> 3)
+            int memoryPosition = 0;
+            while (memoryPosition < source.Length)
             {
-                case IdFieldNumber:
-                    Id = source.ReadInt64(ref memoryPosition);
-                    continue;
-                case InfoFieldNumber:
-                    Info = source.ReadInfo(ref memoryPosition);
-                    continue;
-                case KeySegmentsFieldNumber:
-                    Keys = [.. source.ReadPackedUInt32(ref memoryPosition)];
-                    break;
-                case ValuesFieldNumber:
-                    Values = [.. source.ReadPackedUInt32(ref memoryPosition)];
-                    break;
-                case ReferencesFieldNumber:
-                    References = [.. source.ReadPackedDeltaCodedSInt64(ref memoryPosition)];
-                    break;
-                case LatitudesFieldNumber:
-                    Latitudes = [.. source.ReadPackedDeltaCodedSInt64(ref memoryPosition)];
-                    break;
-                case LongitudesFieldNumber:
-                    Longitudes = [.. source.ReadPackedDeltaCodedSInt64(ref memoryPosition)];
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in Way message.");
+                switch (source.Span[memoryPosition++] >> 3)
+                {
+                    case IdFieldNumber:
+                        Id = source.ReadInt64(ref memoryPosition);
+                        continue;
+                    case InfoFieldNumber:
+                        Info = source.ReadInfo(ref memoryPosition);
+                        continue;
+                    case KeySegmentsFieldNumber:
+                        Keys = source.ReadPackedUInt32(ref memoryPosition).ToArray();
+                        break;
+                    case ValuesFieldNumber:
+                        Values = source.ReadPackedUInt32(ref memoryPosition).ToArray();
+                        break;
+                    case ReferencesFieldNumber:
+                        References = source.ReadPackedDeltaCodedSInt64(ref memoryPosition).ToArray();
+                        break;
+                    case LatitudesFieldNumber:
+                        Latitudes = source.ReadPackedDeltaCodedSInt64(ref memoryPosition).ToArray();
+                        break;
+                    case LongitudesFieldNumber:
+                        Longitudes = source.ReadPackedDeltaCodedSInt64(ref memoryPosition).ToArray();
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown field number [{source.Span[memoryPosition - 1] >> 3}] in Way message.");
+                }
             }
         }
-    }
 
-    public bool Equals(Way? other)
-    {
-        if (other is null) return false;
-        if (ReferenceEquals(this, other)) return true;
-
-        return Id == other.Id &&
-               (Keys ?? []).SequenceEqual(other.Keys ?? []) &&
-               (Values ?? []).SequenceEqual(other.Values ?? []) &&
-               Info == other.Info &&
-               (References ?? []).SequenceEqual(other.References ?? []) &&
-               (Latitudes ?? []).SequenceEqual(other.Latitudes ?? []) &&
-               (Longitudes ?? []).SequenceEqual(other.Longitudes ?? []);
-    }
-
-    public override bool Equals(object? obj) => Equals(obj as Way);
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(
-            Id,
-            GetArrayHashCode(Keys),
-            GetArrayHashCode(Values),
-            Info,
-            GetArrayHashCode(References),
-            GetArrayHashCode(Latitudes),
-            GetArrayHashCode(Longitudes)
-        );
-    }
-    private static int GetArrayHashCode<T>(T[]? array)
-    {
-        if (array is null)
-            return 0;
-        var hash = new HashCode();
-        foreach (var item in array)
+        public bool Equals(Way? other)
         {
-            hash.Add(item);
-        }
-        return hash.ToHashCode();
-    }
-    public static bool operator ==(Way left, Way right) => left?.Equals(right) ?? right is null;
-    public static bool operator !=(Way left, Way right) => !(left == right);
-}
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
 
-internal static class WayMemoryExtensions
-{
-    internal static Way AsWay(this Memory<byte> source)
+            return Id == other.Id &&
+                (Keys ?? Array.Empty<uint>()).SequenceEqual(other.Keys ?? Array.Empty<uint>()) &&
+                (Values ?? Array.Empty<uint>()).SequenceEqual(other.Values ?? Array.Empty<uint>()) &&
+                Info == other.Info &&
+                (References ?? Array.Empty<long>()).SequenceEqual(other.References ?? Array.Empty<long>()) &&
+                (Latitudes ?? Array.Empty<long>()).SequenceEqual(other.Latitudes ?? Array.Empty<long>()) &&
+                (Longitudes ?? Array.Empty<long>()).SequenceEqual(other.Longitudes ?? Array.Empty<long>());
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as Way);
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Id,
+                GetArrayHashCode(Keys),
+                GetArrayHashCode(Values),
+                Info,
+                GetArrayHashCode(References),
+                GetArrayHashCode(Latitudes),
+                GetArrayHashCode(Longitudes)
+            );
+        }
+        private static int GetArrayHashCode<T>(T[]? array)
+        {
+            if (array is null)
+                return 0;
+            var hash = new HashCode();
+            foreach (var item in array)
+            {
+                hash.Add(item);
+            }
+            return hash.ToHashCode();
+        }
+        public static bool operator ==(Way left, Way right) => left?.Equals(right) ?? right is null;
+        public static bool operator !=(Way left, Way right) => !(left == right);
+    }
+
+    internal static class WayMemoryExtensions
     {
-        return new Way(source);
+        internal static Way AsWay(this Memory<byte> source)
+        {
+            return new Way(source);
+        }
     }
 }


### PR DESCRIPTION
Implements #25 

Most of these changes are syntactical, not functional, to account for how the language has evolved in the last few years. The most significant change that was actually functional is how zlib data is decompressed. There is no native support in netstandard2.0 for zlib streams, so we are going to just use ZLibDotNet for now for all target frameworks.

I'm not really concerned about whether there are performance concerns compared to the native ZLibStream provided by newer dotnet runtimes. It is already intended to replace this with a custom zlib decompression implementation. Similar to implementing the protobuf reader manually instead of using a generic language, I think we'll be able to get some good performance improvements by implementing the decompressor knowing what the data will look like, we can make assumptions a generalized library can't. For example, we could implement a query language that allows us to abandon a decompression once we get enough data to know the entire compressed block won't return anything relevant to our query.